### PR TITLE
add initial speech charts

### DIFF
--- a/charts/.helmignore
+++ b/charts/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/ibm-embed-helpers/.helmignore
+++ b/charts/ibm-embed-helpers/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/ibm-embed-helpers/Chart.yaml
+++ b/charts/ibm-embed-helpers/Chart.yaml
@@ -1,0 +1,7 @@
+apiVersion: v2
+name: ibm-embed-helpers
+description: A library chart with shared helpers for the IBM Watson Embed products
+
+type: library
+version: "0.0.0"
+appVersion: "0.0.0"

--- a/charts/ibm-embed-helpers/README.md
+++ b/charts/ibm-embed-helpers/README.md
@@ -1,0 +1,15 @@
+# IBM Embed Helpers
+
+Library chart with common helpers used by the IBM Watson Library for Embed product charts.
+
+## Chart Details
+
+This is a library chart that does not install any resources directly.
+
+## Prerequisites
+
+- [Helm 3](https://helm.sh/docs/intro/install/)
+
+## Documentation
+
+Including this as a sub-chart dependency imports the `ibm-embed-helpers.*` helper templates.

--- a/charts/ibm-embed-helpers/templates/_cert-gen.tpl
+++ b/charts/ibm-embed-helpers/templates/_cert-gen.tpl
@@ -1,0 +1,27 @@
+{{/*
+Generate TLS certificate signed by a CA
+*/}}
+{{- define "ibm-embed-helpers.genCert" -}}
+  {{- $params := . -}}
+  {{- $ca := index $params 0 -}}
+  {{- $altNames := index $params 1 -}}
+
+  {{- $cert := genSignedCert "ibm-watson-embed" nil $altNames 3650 $ca -}}
+  {{- $cert | toJson -}}
+{{- end -}}
+
+{{/*
+Print TLS certificate data as ConfigMap stringData
+*/}}
+{{- define "ibm-embed-helpers.certStringdata" -}}
+  {{- $params := . -}}
+  {{- $ca := index $params 0 -}}
+  {{- $cert := index $params 1 -}}
+  {{- "tls.crt: |" | nindent 2 -}}
+  {{- $cert.Cert | nindent 4 -}}
+  {{- "tls.key: |" | nindent 2 -}}
+  {{- $cert.Key | nindent 4 -}}
+  {{- "ca.crt: |" | nindent 2 -}}
+  {{- $ca.Cert | nindent 4 -}}
+  {{- "\n" -}}
+{{- end -}}

--- a/charts/ibm-embed-helpers/templates/_lib.tpl
+++ b/charts/ibm-embed-helpers/templates/_lib.tpl
@@ -1,0 +1,113 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "ibm-embed-helpers.name" -}}
+  {{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "ibm-embed-helpers.chart" -}}
+  {{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end }}
+
+{{/*
+Create a fully qualified app name to use as a prefix for created resources.
+
+If release name contains chart name it will be used as the full name.
+
+Some Kubernetes name fields are limited to 63 chars by the DNS naming spec.
+Truncate to 30 here to leave space for component names and generated suffixes.
+*/}}
+{{- define "ibm-embed-helpers.fullname" -}}
+  {{- if .Values.fullnameOverride -}}
+    {{- .Values.fullnameOverride | trunc 30 | trimSuffix "-" -}}
+  {{- else -}}
+    {{- $name := default .Chart.Name .Values.nameOverride -}}
+    {{- if contains $name .Release.Name -}}
+      {{- .Release.Name | trunc 30 | trimSuffix "-" -}}
+    {{- else -}}
+      {{- printf "%s-%s" .Release.Name $name | trunc 30 | trimSuffix "-" -}}
+    {{- end -}}
+  {{- end -}}
+{{- end -}}
+
+{{/*
+Resource labels
+*/}}
+{{- define "ibm-embed-helpers.labels" -}}
+  {{- $params := . -}}
+  {{- $root := index $params 0 -}}
+  {{- $compName := index $params 1 -}}
+helm.sh/chart: "{{ include "ibm-embed-helpers.chart" $root }}"
+{{ include "ibm-embed-helpers.selectorLabels" (list $root $compName) }}
+app.kubernetes.io/version: "{{ $root.Chart.AppVersion }}"
+app.kubernetes.io/managed-by: "{{ $root.Release.Service }}"
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "ibm-embed-helpers.selectorLabels" -}}
+  {{- $params := . -}}
+  {{- $root := index $params 0 -}}
+  {{- $compName := index $params 1 -}}
+app.kubernetes.io/name: "{{ include "ibm-embed-helpers.name" $root }}"
+app.kubernetes.io/instance: "{{ $root.Release.Name }}"
+  {{- if $compName }}
+app.kubernetes.io/component: "{{ $compName }}"
+  {{- end }}
+{{- end }}
+
+{{/*
+Image reference with optional tag and digest
+*/}}
+{{- define "ibm-embed-helpers.imageReference" -}}
+  {{- $root := index . 0 -}}
+  {{- $imageConfig := index . 1 -}}
+    {{- with $imageConfig -}}
+        {{- printf "%s/%s" $root.Values.containerRegistry .repository -}}
+        {{- if .tag -}}
+          {{- printf ":%s" .tag -}}
+        {{- end -}}
+        {{- if .digest -}}
+          {{- printf "@%s" .digest -}}
+        {{- end -}}
+    {{- end -}}
+{{- end }}
+
+{{/*
+Common Restrictive Security Contexts
+*/}}
+{{- define "ibm-embed-helpers.containerSecurityContext" -}}
+  {{- "securityContext:" -}}
+    {{- "allowPrivilegeEscalation: false" | nindent 2 -}}
+    {{- "capabilities:" | nindent 2 -}}
+      {{- "drop:" | nindent 4 -}}
+      {{- "- ALL" | nindent 4 -}}
+    {{- "privileged: false" | nindent 2 -}}
+    {{- "readOnlyRootFilesystem: true" | nindent 2 -}}
+    {{- "runAsNonRoot: true" | nindent 2 -}}
+  {{- "\n" -}}
+{{- end -}}
+
+{{- define "ibm-embed-helpers.podSecurityContext" -}}
+  {{- "hostIPC: false" | nindent 0 -}}
+  {{- "hostNetwork: false" | nindent 0 -}}
+  {{- "hostPID: false" | nindent 0 -}}
+  {{- "securityContext:" | nindent 0 -}}
+    {{- "runAsNonRoot: true" | nindent 2 -}}
+  {{- "\n" -}}
+{{- end -}}
+
+{{- define "ibm-embed-helpers.enabledModelImageConfigs" -}}
+  {{- $images := list -}}
+  {{- range $models := .Values.models -}}
+    {{- if .enabled -}}
+      {{- $images = (append $images .) -}}
+    {{- end -}}
+  {{- end -}}
+
+  {{- $images | toYaml -}}
+{{- end -}}

--- a/charts/ibm-watson-stt-embed-runtime/.helmignore
+++ b/charts/ibm-watson-stt-embed-runtime/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/ibm-watson-stt-embed-runtime/Chart.yaml
+++ b/charts/ibm-watson-stt-embed-runtime/Chart.yaml
@@ -1,0 +1,19 @@
+apiVersion: v2
+name: ibm-watson-stt-embed-runtime
+description: |
+  Demonstrates how to configure a deployment of the Watson Speech to Text
+  Library for Embed Runtime server.
+
+  License
+
+  By installing the containers you accept the license terms at:
+  https://www14.software.ibm.com/cgi-bin/weblap/lap.pl?li_formnum=L-DAJI-CHRHDK
+home: https://www.ibm.com/docs/watson-libraries?topic=watson-speech-text-library-embed-home
+
+type: application
+version: "0.1.0"
+appVersion: "1.0.0"
+
+dependencies:
+  - name: ibm-embed-helpers
+    version: "0.0.0"

--- a/charts/ibm-watson-stt-embed-runtime/LICENSE
+++ b/charts/ibm-watson-stt-embed-runtime/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/charts/ibm-watson-stt-embed-runtime/README.md
+++ b/charts/ibm-watson-stt-embed-runtime/README.md
@@ -1,0 +1,117 @@
+# IBM Watson Speech to Text Library for Embed
+
+The Watson Speech to Text Library (STT) for Embed transcribes written text from spoken audio. The service leverages machine learning to combine knowledge of grammar, language structure, and the composition of audio and voice signals to accurately transcribe the human voice.
+
+## Introduction
+
+This chart provides a functioning exemplar install of the IBM Watson Speech to Text Embed runtime on Kubernetes.
+
+This chart should be treated as beta when considering compatibility and future changes. It is recommended to either copy and modify the chart or the manifests it renders.
+
+Find out more about IBM Speech to Text Library for Embed by reading the [product documentation](https://www.ibm.com/docs/watson-libraries?topic=watson-speech-text-library-embed-home).
+
+## Chart Details
+
+This chart installs the following:
+
+- STT runtime Deployment
+  - HAProxy container used for TLS termination
+  - The set of enabled models are downloaded and configured via `initContainers`
+- Service to expose the Deployment
+- ConfigMap with configuration files that are mounted into the containers
+- TLS secrets with a self-signed CA and the server certificate
+
+## Prerequisites
+
+- [Helm 3](https://helm.sh/docs/intro/install/)
+- [Get access to the images with an IBM entitlement key](https://www.ibm.com/docs/watson-libraries?topic=i-accessing-files)
+
+### License acceptance
+
+To run the Speech to Text images (runtime and models) the product licenses must be reviewed and accepted by setting the value `license: true`.
+
+The product licenses are contained in the `/license` directory or can be [viewed online](https://www14.software.ibm.com/cgi-bin/weblap/lap.pl?li_formnum=L-DAJI-CHRHDK).
+
+### Red Hat OpenShift SecurityContextConstraints
+
+Security context constraints (SCCs) can be set on individual containers to control permissions. These permissions include actions a container can perform and what resources it can access. RedHat Openshift has a set of default SCCs to define a set of conditions that a container must run with to be accepted into the system.
+
+These values are preset within the chart:
+
+```yaml
+securityContext:
+  allowPrivilegeEscalation: false
+  capabilities:
+    drop:
+    - ALL
+  privileged: false
+  readOnlyRootFilesystem: true
+  runAsNonRoot: true
+```
+
+## Installing the Chart
+
+The containers deployed in this chart come from the IBM entitled registry. You must create a Secret with credentials to pull from the IBM entitled registry. `ibm-entitlement-key` is the default name, but this can be changed by updating the `imagePullSecrets` value.
+
+An example command to create the pull secret:
+
+```sh
+  $ kubectl create secret docker-registry ibm-entitlement-key \
+  --docker-server=cp.icr.io \
+  --docker-username=<your-name> \
+  --docker-password=<your-password> \
+  --docker-email=<your-email>
+```
+
+Before installing the chart, the license terms must be reviewed. Set `license=true` when installing to accept the license:
+
+```sh
+$ helm install --set license=true --set nameOverride=stt my-release ./ibm-watson-stt-embed-runtime
+```
+
+By default, the models that are enabled are `en-US_Multimedia` and `en-US_Telephony` with `defaultModel` set to `en-US_Multimedia`.
+
+To configure the install further, such as enabling additional models, it is recommended to use a [values configuration file](#configuration).
+
+## Verifying the Chart
+
+See the instruction (from NOTES.txt within chart) after the helm installation completes for chart verification. The instruction can also be viewed by running:
+
+```sh
+$ helm status my-release
+```
+
+## Uninstalling the Chart
+
+To uninstall and delete the installed resources:
+
+```sh
+$ helm delete my-release
+```
+
+## Configuration
+
+Helm charts have configurable values that can be set at install time. Refer to the base [values.yaml](values.yaml) for documentation and defaults for the values. Values can be changed using `--set` or using YAML files specified with `-f/--values`
+
+An example YAML values file can be found below:
+
+```yaml
+# Required to indicate acceptance of the container product license
+license: true
+
+# Use a simpler name for resources created by the Helm chart
+nameOverride: "stt"
+
+# Change the default model when none is specified in the request
+defaultModel: de-DE_Multimedia
+# Enable additional models from the default ones (ensure that the default model is enabled)
+models:
+  arMSTelephony:
+    enabled: true
+  deDEMultimedia:
+    enabled: true
+  deDETelephony:
+    enabled: true
+```
+
+See the [product's configuration documentation](https://www.ibm.com/docs/watson-libraries?topic=r-configuration-options) for details on how the containers are configured.

--- a/charts/ibm-watson-stt-embed-runtime/charts/ibm-embed-helpers
+++ b/charts/ibm-watson-stt-embed-runtime/charts/ibm-embed-helpers
@@ -1,0 +1,1 @@
+../../ibm-embed-helpers/

--- a/charts/ibm-watson-stt-embed-runtime/files/prepareModels.sh
+++ b/charts/ibm-watson-stt-embed-runtime/files/prepareModels.sh
@@ -1,0 +1,40 @@
+#! /usr/bin/env bash
+# The purpose of this script is to process the archives contained in the model
+# container images to populate the model "cache" that the runtime uses when it
+# loads models. If the cache is populated, the runtime loads from it instead of
+# depending on model store service.
+#
+# We use the runtime code itself to populate the cache by booting the runtime
+# with a simple Python file server serving the archives. The runtime imports the
+# models and populates the cache. After the cache is populated, the runtime can
+# boot without the file server.
+set -u
+
+cleanup() {
+  local pids=$(jobs -pr)
+  if [ -n "$pids" ]; then
+    kill $pids
+  fi
+}
+trap "cleanup" SIGINT SIGQUIT SIGTERM EXIT
+
+python -m http.server --bind 127.0.0.1 --directory /models 3333 &
+
+./runChuck.sh &
+
+# wait for the server to become ready, which happens after it downloads the models
+max_tries=10
+tries=0
+while [[ tries -lt max_tries ]]; do
+  curl -sk -o /dev/null "localhost:1080/v1/miniHealthCheck"
+  if [[ $? -eq 0 ]]; then
+    echo "Model initialization complete"
+    exit 0
+  fi
+
+  sleep 1
+  ((tries+=1))
+done
+
+echo "Server failed to initialize models in time."
+exit 1

--- a/charts/ibm-watson-stt-embed-runtime/licenses/LICENSE
+++ b/charts/ibm-watson-stt-embed-runtime/licenses/LICENSE
@@ -1,0 +1,1030 @@
+-----
+
+IMPORTANT: READ CAREFULLY
+
+Two license agreements are presented below.
+
+1. IBM International License Agreement for Evaluation of Programs
+2. IBM International Program License Agreement
+
+If Licensee is obtaining the Program for purposes of productive use (other than evaluation, testing, trial "try or buy," or demonstration): By setting the environment variable ACCEPT_LICENSE=true, Licensee accepts the IBM International Program License Agreement, without modification.
+
+If Licensee is obtaining the Program for the purpose of evaluation, testing, trial "try or buy," or demonstration (collectively, an "Evaluation"): By setting the environment variable ACCEPT_LICENSE=true, Licensee accepts both (i) the IBM International License Agreement for Evaluation of Programs (the "Evaluation License"), without modification; and (ii) the IBM International Program License Agreement (the "IPLA"), without modification.
+
+The Evaluation License will apply during the term of Licensee's Evaluation.
+
+The IPLA will automatically apply if Licensee elects to retain the Program after the Evaluation (or obtain additional copies of the Program for use after the Evaluation) by entering into a procurement agreement (e.g., the IBM International Passport Advantage or the IBM Passport Advantage Express agreements).
+
+The Evaluation License and the IPLA are not in effect concurrently; neither modifies the other; and each is independent of the other.
+
+The complete text of each of these two license agreements follow.
+
+The translated license terms can be viewed here: https://www14.software.ibm.com/cgi-bin/weblap/lap.pl?li_formnum=L-DAJI-CHRHDK
+
+-----
+
+LICENSE INFORMATION
+
+The Programs listed below are licensed under the following License Information terms and conditions in addition to the Program license terms previously agreed to by Client and IBM. If Client does not have previously agreed to license terms in effect for the Program, the International Program License Agreement (i125-3301-15) applies.
+
+Program Name (Program Number):
+IBM Watson Speech to Text Library for Embed 1.0.0 (5900-AT9)
+
+The following standard terms apply to Licensee's use of the Program.
+
+Modifiable Third Party Code
+
+To the extent, if any, in the NOTICES file IBM identifies third party code as "Modifiable Third Party Code," IBM authorizes Licensee to 1) modify the Modifiable Third Party Code and 2) reverse engineer the Program modules that directly interface with the Modifiable Third Party Code provided that it is only for the purpose of debugging Licensee's modifications to such third party code. IBM's service and support obligations, if any, apply only to the unmodified Program.
+
+Separately Licensed Code
+
+Each of the components listed in the NON_IBM_LICENSE file is considered "Separately Licensed Code" licensed to Licensee under the terms of the applicable third party license agreement(s) set forth in the NON_IBM_LICENSE file(s) that accompanies the Program, and not this Agreement. Future Program updates or fixes may contain additional Separately Licensed Code. Such additional Separately Licensed Code and related licenses are listed in the applicable NON_IBM_LICENSE file that accompanies the Program update or fix.
+
+Note: Notwithstanding any of the terms in the third party license agreement, the Agreement, or any other agreement Licensee may have with IBM, with respect to the Separately Licensed Code:
+(a) IBM provides it to Licensee WITHOUT WARRANTIES OF ANY KIND AND DISCLAIMS ANY AND ALL EXPRESS AND IMPLIED WARRANTIES AND CONDITIONS INCLUDING, BUT NOT LIMITED TO, THE WARRANTY OF TITLE, NON-INFRINGEMENT OR NON-INTERFERENCE, AND THE IMPLIED WARRANTIES AND CONDITIONS OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE;
+(b) IBM is not liable for any direct, indirect, incidental, special, exemplary, punitive or consequential damages including, but not limited to, lost data, lost savings, and lost profits.
+
+Benchmarking
+
+Licensee may disclose the results of any benchmark test of the Program or its subcomponents to any third party provided that Licensee (A) publicly discloses the complete methodology used in the benchmark test (for example, hardware and software setup, installation procedure and configuration files), and (B) performs testing running the Program in its Specified Operating Environment using the latest applicable updates, patches, fixes, performance tuning, and best practices guidance available for the Program,. If Licensee publishes the results of any benchmark tests for the Program, then IBM (including third parties providing IBM products "Third Parties") will have the right to publish the results of benchmark tests with respect to Licensee's products provided IBM or Third Parties complies with the requirements of (A), and (B) above in its testing of Licensee's products.
+
+Notwithstanding the foregoing, under no circumstances may Licensee publish the results of benchmark tests run on Oracle Outside In Technology without prior written permission.
+
+The following units of measure may apply to Licensee's use of the Program.
+
+Monthly Minute
+
+Monthly Minute is a unit of measure by which the Program can be licensed. A Minute is a unit of time equal to 60 seconds. Total number of whole or partial Minutes in any calendar month are added together and then rounded up to the nearest whole Minute. Sufficient entitlements must be obtained to cover the number of Minutes analyzed or processed by the Program in any calendar month.
+
+L/N:  L-DAJI-CHRHDK
+D/N:  L-DAJI-CHRHDK
+P/N:  L-DAJI-CHRHDK
+
+
+
+-----
+
+International Program License Agreement
+
+Part 1 - General Terms
+
+BY DOWNLOADING, INSTALLING, COPYING, ACCESSING, CLICKING ON AN "ACCEPT" BUTTON, OR OTHERWISE USING THE PROGRAM, LICENSEE AGREES TO THE TERMS OF THIS AGREEMENT. IF YOU ARE ACCEPTING THESE TERMS ON BEHALF OF LICENSEE, YOU REPRESENT THAT YOU HAVE FULL AUTHORITY TO BIND LICENSEE TO THESE TERMS.
+
+IF YOU DO NOT AGREE TO THESE TERMS OR DO NOT HAVE AUTHORITY: i) DO NOT DOWNLOAD, INSTALL, COPY, ACCESS, CLICK ON AN "ACCEPT" BUTTON, OR USE THE PROGRAM; AND ii) PROMPTLY RETURN THE UNUSED MEDIA, DOCUMENTATION, AND PROOF OF ENTITLEMENT TO THE PARTY FROM WHOM IT WAS OBTAINED FOR A REFUND OF THE AMOUNT PAID. IF THE PROGRAM WAS DOWNLOADED, DESTROY ALL COPIES OF THE PROGRAM.
+
+This International Program License Agreement (IPLA) and applicable Transaction Documents (together the "Agreement") are the complete agreement between Licensee and IBM regarding the use of a Program. The country required terms included in Part 2 of this IPLA replace or modify the terms of Part 1.
+
+Transaction Documents (TDs) provide a description, information, and terms regarding the Program and its authorized use. Examples of TDs for Programs include license information (LI), licensed program specifications (LPS), quote, proof of entitlement (PoE), or invoice. To the extent of any conflict a TD will prevail over the IPLA.
+
+1. Program License
+
+a. A Program is an executable IBM-branded computer program and its related material and includes whole and partial copies. Program details are described in a TD available at http://www.ibm.com/software/sla (for Passport Advantage Programs) or http://www.ibm.com/support/knowledgecenter (for other IBM Programs), in the Program's system command directory, or as otherwise specified by IBM. IBM software policies (such as backup, temporary use and IBM approved cloud environment) available at http://www.ibm.com/softwarepolicies apply to Licensee's use of Programs.
+
+b. Copies of Programs are copyrighted and licensed.
+
+c. Licensee is granted a nonexclusive license to:
+
+(1) use each copy of a Program, subject to the terms of the Agreement and up to the number of license entitlements Licensee acquires ("Authorized Use");
+
+(2) make and install copies to support such Authorized Use; and
+
+(3) make a backup copy.
+
+d. Programs may be used by Licensee, its employees and contractors. Licensee may not rent or lease a Program or provide commercial IT, hosting or timesharing services to any third party. Additional rights may be available for additional fees or under different terms.
+
+e. The license granted for a Program is subject to Licensee:
+
+(1) reproducing copyright notices and other markings on any copy;
+
+(2) ensuring anyone who uses the Program: i) does so only on Licensee's behalf within Licensee's Authorized Use; and ii) complies with this Agreement;
+
+(3) not reverse assembling, reverse compiling, translating, or reverse engineering the Program, except as expressly permitted by law without the possibility of contractual waiver; and
+
+(4) not using any of the elements of the Program or related licensed materials separately from the Program.
+
+f. If the TD for a Program ("Principal Program") states that a "Supporting Program" is included with the Principal Program, Licensee may use the Supporting Program subject to any license limitations of the Principal Program and only to support the Principal Program.
+
+g. This license applies to each copy of the Program that Licensee makes.
+
+h. An update, fix, or patch to a Program is subject to the terms governing the Program unless new terms are provided in an updated TD. Licensee accepts such new terms upon installation of the update, fix, or patch. If a Program is replaced by an update, Licensee agrees to promptly discontinue use of the replaced Program.
+
+i. If Licensee is dissatisfied with a Program for any reason, Licensee may terminate the license by returning the Program and proof of entitlement to IBM or the authorized IBM Business Partner within 30 days of the original acquisition date of such Program for a refund of the amount paid. For a downloaded Program, contact the party Licensee acquired the Program from for refund instructions.
+
+2. Warranties
+
+a. IBM warrants that a Program, when used in its specified operating environment conforms to its specifications. The warranty period for a Program is 12 months from acquisition, or the initial license term if less than 12 months, unless another warranty period is specified in the TD.
+
+b. During the warranty period Licensee will have access to IBM databases containing information on known Program defects, defect corrections, restrictions, and bypasses as described in the IBM Support Guide at http://www.ibm.com/support/pages/node/733923.
+
+c. If the Program does not function as warranted during its warranty period and the problem cannot be resolved with information available in the IBM databases, Licensee may return the Program and proof of entitlement to IBM or the IBM Business Partner for a refund of the amount Licensee paid and Licensee's license terminates.
+
+d. IBM does not warrant uninterrupted or error-free operation of an IBM Program or that IBM will correct all defects or prevent third party disruptions. These warranties are the exclusive warranties from IBM and replace all other warranties, including the implied warranties or conditions of satisfactory quality, merchantability, non-infringement, and fitness for a particular purpose. IBM warranties will not apply if there has been misuse, modification, damage not caused by IBM, or failure to comply with written instructions provided by IBM. Non-IBM Programs are provided as-is, without warranties of any kind. Third parties may provide their own warranties to Licensee.
+
+e. Additional support available during or after the warranty period may be available under separate agreement.
+
+3. Charges, Taxes, Payment, and Verification
+
+a. Licensee's right to use a Program is contingent on Licensee paying applicable charges as specified in the agreement under which Licensee acquired the license entitlements. Licensee is responsible to acquire additional license entitlements in advance of any increase of its use.
+
+b. Licensee agrees to pay all applicable charges for acquired entitlements and any charges for use in excess of authorizations. Charges are exclusive of any customs or other duty, tax, and similar levies imposed by any authority resulting from Licensee's acquisition of entitlements and will be invoiced in addition to such charges. Amounts are due upon receipt of the invoice from IBM and payable within 30 days of the invoice date to an account specified by IBM and late payment fees may apply. Licensee is responsible to properly acquire additional license entitlements in advance to increase its use. IBM does not give credits or refunds for charges already due or paid, except as specified elsewhere in this IPLA, the applicable TD, or terms of the agreement under which Licensee acquired license entitlements.
+
+c. Based on acquired entitlements, Licensee agrees to: i) pay any withholding tax directly to the appropriate government entity where required by law; ii) furnish a tax certificate evidencing such payment to IBM; iii) pay IBM only the net proceeds after tax; and iv) fully cooperate with IBM in seeking a waiver or reduction of such taxes and promptly complete and file all relevant documents.
+
+d. If Licensee imports, exports, transfers, accesses, or uses a Program across a border, Licensee agrees to be responsible for and pay authorities any custom, duty, tax, or similar levy assessed by the authorities. This excludes those taxes based on IBM's net income.
+
+3.1 Licensing Verification
+
+a. Licensee will, for all Programs at all sites and for all environments, create, retain, and each year provide to IBM upon request with 30 days' advance notice: i) a report, in a format requested by IBM using records, system tools output, and other system information; and ii) supporting documentation (collectively, "Deployment Data").
+
+b. Upon reasonable notice, IBM and its independent auditors may verify Licensee's compliance with this Agreement, at all sites and for all environments, in which Licensee uses (for any purposes) Programs. Verification will be conducted in a manner that minimizes disruption to Licensee's business and may be conducted on Licensee's premises, during normal business hours. IBM will have a written confidentiality agreement with the independent auditor. In addition to providing Deployment Data described above, Licensee agrees to provide to IBM and its auditors additional accurate information and Deployment Data upon request.
+
+c. Licensee will promptly order and pay charges at IBM's then current rates associated with: i) any deployments in excess of authorizations indicated on or by any annual report or verification; ii) applicable subscription & support services (S&S) for such excess deployments for the lesser of the duration of such excess use or two years; and iii) any additional charges and other liabilities determined as a result of such verification, including but not limited to taxes, duties, and regulatory fees.
+
+4. Liability and Intellectual Property Protection
+
+a. IBM's entire liability for all claims related to this Agreement will not exceed the amount of any actual direct damages incurred by Licensee up to the amounts paid (if recurring charges, up to 12 months' charges apply) for the entitlements to the Program that is the subject of the claim, regardless of the basis of the claim. IBM will not be liable for special, incidental, exemplary, indirect, or economic consequential damages, or for lost profits, business, value, revenue, goodwill, or anticipated savings. These limitations apply collectively to IBM, its affiliates, contractors, and suppliers.
+
+b. The following amounts are not subject to the above cap: i) third party payments related to infringement claims described in clause 4 c below; and ii) damages that cannot be limited under applicable law.
+
+c. If a third party asserts a claim against Licensee that an IBM Program infringes a patent or copyright, IBM will defend Licensee against that claim and pay amounts finally awarded by a court against Licensee or included in a settlement approved by IBM. To obtain IBM's defense against and payment of infringement claims, Licensee must promptly: i) notify IBM in writing of the claim; ii) supply information requested by IBM; and iii) allow IBM to control, and reasonably cooperate in, the defense and settlement, including mitigation efforts. IBM's defense and payment obligations for infringement claims extend to claims of infringement based on open source code that IBM selects and embeds in an IBM Program.
+
+d. IBM has no responsibility for claims based on non-IBM products, items not provided by IBM, or any violation of law or third party rights caused by Content, or any Licensee materials, designs, specifications, or use of a non-current version or release of an IBM Program when an infringement claim could have been avoided by using a current version or release. Content consists of all data, software, and information that Licensee or its authorized users provide, authorize access to, or inputs to a Program.
+
+5. Termination
+
+a. IBM may terminate Licensee's license to use a Program if Licensee fails to comply with the IPLA, TDs or acquisition agreements, such as the International Passport Advantage Agreement (IPAA). Licensee will promptly destroy all copies of the Program after license termination. Any terms that by their nature extend beyond the termination remain in effect until fulfilled and apply to successors and assignees.
+
+6. Governing Laws and Geographic Scope
+
+a. Both parties agree to the application of the laws of the country where the transaction for license entitlements is performed, without regard to conflict of law principles. The rights and obligations of each party are valid only in the country where the transaction to acquire license entitlements is performed or, if IBM agrees, the country where the Program is placed in productive use, except all licenses are valid as specifically granted.
+
+b. Each party is also responsible for complying with: i) laws and regulations applicable to its business and Content; and ii) import, export and economic sanction laws and regulations, including the defense trade control regime of the United States of America and any applicable jurisdictions, that prohibit or restrict the import, export, re-export, or transfer of products, technology, services or data, directly or indirectly, to or for certain countries, end uses or end users.
+
+c. If any provision of this Agreement for a Program, is invalid or unenforceable, the remaining provisions remain in full force and effect. Nothing in this Agreement affects statutory rights of consumers that cannot be waived or limited by contract. The United Nations Convention on Contracts for the International Sale of Goods does not apply to transactions under this Agreement.
+
+7. General
+
+a. IBM is an independent contractor, not Licensee's agent, joint venturer, partner, or fiduciary, and does not undertake to perform any of Licensee's regulatory obligations, or assume any responsibility for Licensee's business or operations. Licensee is responsible for its use of IBM Programs and Non-IBM Programs. IBM is acting as an information technology provider only. IBM's direction, suggested usage, or guidance or use of a Program does not constitute medical, clinical, legal, accounting, or other licensed professional advice. Licensee should obtain its own expert advice.
+
+b. For Programs IBM provides to Licensee in tangible form, IBM fulfills its shipping and delivery obligations upon the delivery of such Programs to the IBM-designated carrier, unless otherwise agreed to in writing by Licensee and IBM.
+
+c. Licensee may not use the Program if failure of the Program could lead to death, serious bodily injury, or property or environmental damage.
+
+d. IBM, its affiliates, and contractors of either require use of business contact information and certain account usage information. This information is not Content. Business contact information is used to communicate and manage business dealings with the Licensee. Examples of business contact information include name, business telephone, address, email, user ID, and tax registration information. Account usage information is required to enable, provide, manage, support, administer, and improve Programs. Examples of account usage information include reported errors and digital information gathered using tracking technologies, such as cookies and web beacons, during use of the Programs. The IBM Privacy Statement at http://www.ibm.com/privacy provides additional details with respect to IBM's collection, use, and handling of business contact and account usage information. When Licensee provides information to IBM and notice to, or consent by, the individuals is required for such processing, Licensee will notify individuals and obtain consent.
+
+e. IBM Business Partners who use or make available Programs are independent from IBM and unilaterally determine their prices and terms. IBM is not responsible for their actions, omissions, statements, or offerings.
+
+f. IBM may offer Non-IBM Programs, or an IBM Program may enable access to Non-IBM Programs, that may require acceptance of third party terms identified in a TD or presented to the Licensee. Linking to or use of Non-IBM Programs constitutes Licensee's agreement with such terms. IBM is not a party to any third party agreement and is not responsible for such Non-IBM Programs.
+
+g. License grants to Programs are provided by International Business Machines Corporation, a New York corporation ("IBM Corporation"). The IBM company from which the Licensee acquires entitlements ("IBM") is acting as a distributor and delivering Programs and is responsible for enforcing the terms of this Agreement. If entitlements are acquired from an IBM Business Partner, the IBM company for the country of acquisition is responsible for enforcing the terms of this Agreement. No right or cause of action is created in favor of Licensee against IBM Corporation. Licensee waives all claims and causes of action against IBM Corporation and agrees to look solely to IBM for any rights and remedies in connection with Programs.
+
+h. Licensee may not sublicense, assign, or transfer the license for any Program (except to the extent assignment or transfer may not be legally restricted or as is expressly permitted in a TD or as otherwise agreed by IBM). IBM may assign its rights and obligations under this Agreement in conjunction with the sale of the portion of IBM's business that includes a Program. IBM may share this Agreement and related documents in conjunction with any assignment.
+
+i. All notices under the Agreement must be in writing and sent to the business address specified in the agreement Licensee acquired the license entitlements unless a party designates in writing a different address. The parties consent to the use of electronic means and facsimile transmissions for communications as a signed writing. Any reproduction of the Agreement made by reliable means is considered an original. Agreement supersedes any course of dealing, discussions or representations, between the parties.
+
+j. No right or cause of action for any third party is created by the Agreement. Neither party will bring a legal action arising out of or related to the Agreement more than two years after the cause of action arose. Neither party is responsible for failure to fulfill its non-monetary obligations due to causes beyond its control. Each party will allow the other reasonable opportunity to comply before it claims the other has not met its obligations.
+
+k. IBM may use personnel and resources in locations worldwide, including third party contractors to support the delivery of Programs and Program support. Licensee's use of Programs may result in the transfer of Content, including personally identifiable information, across country borders to provide Program support as described in the IBM Software Support Guide.
+
+Part 2 - Country Required Terms
+
+For licenses acquired in the countries specified below, the following terms replace or modify the referenced terms of this IPLA. Terms not changed by these amendments remain unchanged and in effect.
+
+1. AMERICAS
+
+Section 3. Charges, Taxes, Payment, and Verification
+
+Replace the first and second sentence of paragraph b with the following:
+
+In Brazil: Licensee agrees to pay all applicable charges for acquired entitlements and any charges for use in excess of authorizations and any customs or other duty, tax, and similar levies imposed by any authority resulting from Licensee's acquisition of entitlements.
+
+In paragraph b:
+
+In Mexico: In the third sentence, delete the words "to an account specified by IBM".
+
+In Mexico: Add the following new sentence after the third sentence:
+
+Payments will be made through electronic transfer of funds to an account specified by IBM or in IBM's domicile which is located in Alfonso Napoles Gandara 3111, Santa Fe Peña Blanca, Alvaro Obregon, Mexico City, Zip Code 01210.
+
+Add at the end of paragraph c the following sentence:
+
+In Canada: Where taxes are based upon the location(s) receiving the benefit of the Program, Licensee has an ongoing obligation to notify IBM of such location(s) if different than Licensee's business address listed in the applicable TD.
+
+Add at the end of paragraph c the following sentence:
+
+In United States: The parties agree no tangible personal property (e.g. media or publications) shall transfer to Licensee if: i) IBM delivers Programs electronically to Licensee; or ii) Licensee claims a sales or use tax exemption for Programs IBM delivers electronically to Licensee. Where taxes are based upon the location(s) receiving the benefit of the Program, Licensee has an ongoing obligation to notify IBM of such location(s) if different than Licensee's business address listed in the applicable TD.
+
+Section 4. Liability and Intellectual Property Protection
+
+Insert the following disclaimer at the end of paragraph a:
+
+In Peru: In accordance with Article 1328 of the Peruvian Civil Code this limitations and exclusions will not apply in the cases of willful misconduct ("dolo") or gross negligence ("culpa inexcusable").
+
+Section 6. Governing Laws and Geographic Scope
+
+In paragraph a, replace the first sentence only with:
+
+In Argentina: Both parties agree to the application of the laws of the Republic of Argentina, without regard to the conflict of law principles. Any proceeding regarding the rights, duties, and obligations arising from this Agreement will be brought in the Ordinary Commercial Court of the City of "Ciudad Autónoma de Buenos Aires".
+
+In Chile: Both parties agree to the application of the laws of Chile, without regard to the conflict of law principles. Any conflict, interpretation or breach related to this Agreement that cannot be solved by the Parties should be remitted to the jurisdiction of the Ordinary Courts of the city and district of Santiago.
+
+In Colombia: Both parties agree to the application of the laws of the Republic of Colombia, without regard to the conflict of law principles. All rights, duties and obligations are subject to the judges of the Republic of Colombia.
+
+In Ecuador: Both parties agree to the application of the laws of the Republic of Ecuador, without regard to the conflict of law principles. Any dispute arising out or relating to this Agreement will be submitted to the civil judges of Quito and to the verbal summary proceeding.
+
+In Venezuela: Both parties agree to the application of the laws of Venezuela, without regard to the conflict of law principles. The parties agree to submit any conflict related to this Agreement, existing between them to the Courts of the Metropolitan Area of the City of Caracas.
+
+In Peru: Both parties agree to the application of the laws of Peru, without regard to the conflict of law principles. Any discrepancy that may arise between the parties in the execution, interpretation or compliance of this Agreement that may not be directly resolved shall be submitted to the Jurisdiction and Competence of the Judges and Tribunals of the 'Cercado de Lima' Judicial District.
+
+In Uruguay: Both parties agree to the application of the laws of Uruguay. Any discrepancy that may arise between the parties in the execution, interpretation or compliance of this Agreement that may not be directly resolved shall be submitted to the Montevideo Courts ("Tribunales Ordinarios de Montevideo").
+
+In paragraph a, first sentence only, replace the phrase, "the country where the transaction for license entitlements is performed" with:
+
+In United States, Anguilla, Antigua/Barbuda, Aruba, Bahamas, Barbados, Bermuda, Bonaire, British Virgin Islands, Cayman Islands, Curacao, Dominica, Grenada, Guyana, Jamaica, Montserrat, Saba, Saint Eustatius, Saint Kitts and Nevis, Saint Lucia, Saint Maarten, Saint Vincent and the Grenadines, Suriname, Tortola, Trinidad and Tobago, and Turk and Caicos: the State of New York, United States.
+
+In Canada: the Province of Ontario and the federal laws of Canada applicable therein.
+
+In paragraph a, second sentence, replace the phrase, "the country where the transaction to acquire license entitlements is performed" with:
+
+In Argentina: Argentina
+
+In Chile: Chile
+
+In Colombia: Colombia
+
+In Ecuador: Ecuador
+
+In Mexico: Mexico
+
+In Peru: Peru
+
+In Uruguay: Uruguay
+
+In Venezuela: Venezuela
+
+Add the following sentences at the end of paragraph b:
+
+In Brazil: All disputes arising out of or related to this Agreement, including summary proceedings, will be brought before and subject to the exclusive jurisdiction of the Forum of the City of São Paulo, State of São Paulo, Brazil and the parties irrevocably agree with this specific jurisdiction renouncing any other, however privileged it may be.
+
+In Mexico: The Parties agree to submit themselves to the exclusive jurisdiction of the courts of Mexico City to resolve any dispute arising from this Agreement. The Parties waive to any other jurisdiction that may correspond to them due to their current or future domiciles, or for any other reason.
+
+Section 7. General
+
+In paragraph g:
+
+In United States: delete the last 2 sentences.
+
+In paragraph i, add the following new sentence after the first sentence:
+
+In Mexico: Any change of address must be notified 10 (ten) days in advance, otherwise the notifications made at the last indicated address will have full legal effects.
+
+In paragraph j:
+
+In Brazil: delete the entire 2nd sentence of "Neither party will bring a legal action arising out of or related to the Agreement more than two years after the cause of action arose".
+
+Add as a new paragraph l to this section:
+
+In Canada: Both parties agree to write this document in English. Les parties ont convenu de rédiger le présent document en langue anglaise.
+
+2. ASIA PACIFIC
+
+Section 2. Warranties
+
+Add at the end of this section as a new paragraph f:
+
+In Australia: These warranties are in addition to any rights under, and only limited to the extent permitted by, the Competition and Consumer Act 2010.
+
+In Japan: IBM's liability is limited to this paragraph and the Liability and Intellectual Property Protection section, applicable TDs as Licensee's sole remedy for failure to meet the warranties specified in this section.
+
+In New Zealand: These warranties are in addition to any rights under the Consumer Guarantee Act 1993 or other legislation that cannot be limited by law.
+
+Section 3. Charges, Taxes, Payment, and Verification
+
+In paragraph b. replace the third sentence with the following 2 sentences:
+
+In Hong Kong, Indonesia, Korea, Macau, Malaysia, Philippines, Singapore, and Vietnam: Amounts are due upon receipt of the invoice from IBM and payable within 30 days of the invoice date to an account specified by IBM. If payment is not received within 30 days from the invoice date, IBM may charge a late payment fee on the amount outstanding, calculated on the number of days the payment is received late, at the lesser of: i) 2% for every 30 day period or portion thereof; or ii) the maximum amount permissible by applicable law.
+
+In Thailand: Amounts are due upon receipt of the invoice from IBM and payable within 30 days of the invoice date to an account specified by IBM. If payment is not received within 30 days from the invoice date, a late payment fee may be applied on the amount outstanding, at the rate of 1.25% per month, calculated on the number of days the payment is received late.
+
+In the first sentence of paragraph c, remove the word "and" before "(iv)", and add a semicolon and the following new item "(v)":
+
+In India: ; and (v) file accurate Taxes Deducted at Source (TDS) returns on a timely basis. If any tax, duty, levy or fee ("Taxes") are not charged on the basis of the exemption documentation provided by the Licensee and the taxation authority subsequently rules that such Taxes should have been charged, then the Licensee will be liable to pay such Taxes, including any interests, levies and/or penalties applicable thereon.
+
+In the first sentence of paragraph c, remove the word "and" before "(iv)", and replace item (iv) and add new item (v) with:
+
+In Singapore, Malaysia, Philippines, Thailand, Indonesia, and Vietnam: (iv) fully cooperate with IBM in seeking a waiver or reduction of withholding or other tax that Licensee requests a waiver or reduction; and v) promptly complete, file, and keep current all relevant documents for any such waiver, reductions, or exemptions.
+
+Section 4. Liability and Intellectual Property Protection
+
+In paragraph a, add at the end of the first sentence the following:
+
+In Australia: (for example, whether based in contract, tort, negligence, under statute or otherwise)
+
+In paragraph a, second sentence after the word "special" and before the word "incidental", add the following:
+
+In Philippines: (including nominal and exemplary damages), moral,
+
+Add as a new paragraph after the end of paragraph a (and ensure paragraphs properly reletter):
+
+In Australia: Where IBM is in breach of a guarantee implied by the Competition and Consumer Act 2010, IBM's liability is limited to the repair or replacement of goods or the supply of equivalent goods, or the payment of the cost of replacing the goods or having the good repaired. Where a guarantee relates to the right to sell, quiet possession, or clear title of a good under schedule 2 of the Competition and Consumer Act, then none of these limitations apply.
+
+Section 5. Termination
+
+Add at the end of the section as a new paragraph b:
+
+In Indonesia: The parties waive article 1266 of the Indonesian Civil Code to the extent it requires a court decree for the termination of an agreement creating mutual obligations.
+
+Section 6. Governing Laws and Geographic Scope
+
+In paragraph a, in the first sentence only, replace the phrase, "the country where the transaction for license entitlements is performed" with:
+
+In Cambodia, Laos: the State of New York, United States
+
+In Australia: the State or Territory in which the transaction is performed
+
+In Hong Kong: the Hong Kong Special Administrative Region of the People's Republic of China
+
+In Macau: the Hong Kong Special Administrative Region of the People's Republic of China
+
+In Korea: the Republic of Korea, and subject to the Seoul Central District Court of the Republic of Korea
+
+In Taiwan: Taiwan
+
+In India: India
+
+In paragraph a, in the second sentence, replace the phrase "the country where the transaction to acquire license entitlements is performed or, if IBM agrees, the country where the Program is placed in productive use" with:
+
+In Hong Kong: the Hong Kong Special Administrative Region of the People's Republic of China
+
+In Macau: the Macau Special Administrative Region of the People's Republic of China
+
+In Taiwan: Taiwan
+
+In paragraph b, in the first sentence, item ii), after the word "including" and before words "the defense", add:
+
+In Japan: those of Japan laws and
+
+Add at the end of the section as a new paragraph d:
+
+In Cambodia, Laos, Philippines, and Sri Lanka: Disputes will be finally settled by arbitration in Singapore under the Arbitration Rules of the Singapore International Arbitration Center ("SIAC Rules").
+
+In India: Disputes shall be finally settled in accordance with The Arbitration and Conciliation Act, 1996 then in effect, in English, with seat in Bangalore, India. There shall be one arbitrator if the amount in dispute is less than or equal to Indian Rupee five crores and three arbitrators if the amount is more. When an arbitrator is replaced, proceedings shall continue from the stage they were at when the vacancy occurred.
+
+In Indonesia: Disputes will be finally settled by arbitration in Jakarta, Indonesia, administered by the Indonesian National Board of Arbitration established in the year 1977 ("Badan Arbitrase Nasional Indonesia" or "BANI") in accordance with the rules of the Indonesian National Board of Arbitration The arbitration award shall be final and binding on the parties without appeal and shall be in writing and set forth the findings of fact and the conclusion of law.
+
+In People's Republic of China: Either party has the right to submit the dispute to the China International Economic and Trade Arbitration Commission in Beijing, the PRC, for arbitration. The parties agree three arbitrators will be used to resolve any dispute.
+
+In Vietnam: Disputes will be finally settled by arbitration in Vietnam under the Arbitration Rules of the Vietnam International Arbitration Centre ("VIAC Rules"). All proceedings and documents presented will be in the English language.
+
+Section 7. General
+
+In paragraph j, in the second sentence, replace the phrase "two years" with:
+
+In India: three years
+
+Add to the end of this section the following new paragraph l:
+
+In Indonesia: This agreement is made in the English and Bahasa Indonesian language versions. To the extent permitted by the applicable law, the English version will prevail in the event of conflict between such versions.
+
+3. EUROPE, MIDDLE EAST, AND AFRICA
+
+Section 2. Warranties
+
+In paragraph d, Replace the fourth sentence with the following two sentences:
+
+In Czech Republic, Estonia, and Lithuania: Non-IBM Programs are provided as-is, without warranties of any kind or liabilities for defects. The parties hereby exclude any liability of IBM for defects beyond the agreed warranties.
+
+Section 3. Charges, Taxes, Payment, and Verification
+
+In paragraph b, add the following to the end of the third sentence:
+
+In Italy: if IBM requests in a written notice to Licensee.
+
+In Ukraine: , on the overdue amount from the next day after the due date up to the date of actual payment, prorated for each day of delay, at the interest rate of double the discount rate determined by the National Bank of Ukraine (NBU) during the delay period (paragraph 6 of article 232 of Commercial Code of Ukraine does not apply).
+
+In paragraph b, replace the third sentence with the following:
+
+In France: Amounts are due and payable within 10 days of the invoice date to an account specified by IBM and late payment fees apply equal to the most recent European Central Bank rate plus 10 points, in addition to debt collection costs of forty (40) euros or, if these costs exceed forty euros, complementary indemnification subject to justification of the amount claimed).
+
+In Russia: Amounts are due upon receipt of the invoice and payable within 30 days of the invoice date through electronic transfer of funds to an account specified by IBM. Late payment fees at the rate of 24% per annum calculated for each day beyond the 30 days may apply.
+
+In paragraph b, add the following to the end of the last sentence:
+
+In Lithuania: , or except as provided by law
+
+At the end of paragraph b, add the following:
+
+In Italy: In the instance of no payment or partial payment, and also following a formal credit claim procedure or trial that IBM may initiate, in derogation of article 4 of Legislative Decree n. 231 dated October 9, 2002, and according to article 7 of the same Legislative Decree, IBM will notify Licensee in writing by registered, return receipt mail of late payment fees due.
+
+Section 4. Liability and Intellectual Property Protection
+
+In paragraph a, in the first sentence insert the following before the words "the amounts paid":
+
+In Belgium, France, Germany, Italy, Luxembourg, Malta, Portugal, and Spain: the greater of €500,000 (five hundred thousand euro) or
+
+In Ireland and United Kingdom: 125% of
+
+In paragraph a, in the first sentence, replace the phrase "direct damages incurred by Licensee" with:
+
+In Spain: and proven damages incurred by Licensee as a direct consequence of the IBM default
+
+In paragraph a, insert after the first sentence the following new sentence:
+
+In Slovakia: Referring to § 379 of the Commercial Code, Act No. 513/1991 Coll. as amended, and concerning all conditions related to the conclusion of the agreement, both parties state that the total foreseeable damage, which may accrue, shall not exceed the amount above, and it is the maximum for which IBM is responsible.
+
+In paragraph a, insert before the second sentence the following new sentence:
+
+In Russia: IBM will not be liable for the forgone benefit.
+
+In paragraph a, in the second sentence, delete the word:
+
+In Ireland and United Kingdom: economic
+
+In paragraph a, replace the second sentence with:
+
+In Belgium, Netherlands, and Luxembourg: IBM will not be liable for indirect or consequential damages, lost profits, business, value, revenue, goodwill, damage to reputation or anticipated savings, any third party claim against Licensee, and loss of (or damage to) data.
+
+In France: IBM will not be liable for damages to reputation, indirect damages, or lost profits, business, value, revenue, goodwill, or anticipated savings.
+
+In Portugal: IBM will not be liable for indirect damages, including loss of profit.
+
+In Spain: IBM will not be liable for damage to reputation, lost profits, business, value, revenue, goodwill, or anticipated savings.
+
+Add the following at the end of paragraph a:
+
+In France: The terms of the Agreement, including financial terms, were established in consideration of the present clause, which is an integral part of the general economy of the Agreement.
+
+In paragraph b, replace "and ii) damages that cannot be limited under applicable law" with the following:
+
+In Germany: ; ii) damages for body injury (including death); iii) loss or damage caused by a breach of guarantee assumed by IBM in connection with any transaction under this Agreement; and iv) caused intentionally or by gross negligence.
+
+Section 6. Governing Laws and Geographic Scope
+
+In paragraph a, first sentence only, replace the phrase "the country where the transaction for license entitlements is performed" with:
+
+In Albania, Armenia, Azerbaijan, Belarus, Bosnia-Herzegovina, Bulgaria, Croatia, Former Yugoslav Republic of Macedonia, Georgia, Kazakhstan, Kyrgyzstan, Moldova, Montenegro, Romania, Russia, Serbia, Tajikistan, Turkmenistan, Ukraine, and Uzbekistan: Austria
+
+In Estonia, Latvia, and Lithuania: Finland
+
+In Algeria, Andorra, Benin, Burkina Faso, Burundi, Cameroon, Cape Verde, Central African Republic, Chad, Comoros, Congo Republic, Djibouti, Democratic Republic of Congo, Equatorial Guinea, French Guiana, French Polynesia, Gabon, Guinea, Guinea-Bissau, Ivory Coast, Lebanon, Madagascar, Mali, Mauritania, Mauritius, Mayotte, Morocco, New Caledonia, Niger, Reunion, Senegal, Seychelles, Togo, Tunisia, Vanuatu, and Wallis and Futuna: France
+
+In Angola, Bahrain, Botswana, Egypt, Eritrea, Ethiopia, Gambia, Ghana, Iraq, Jordan, Kenya, Kuwait, Liberia, Malawi, Malta, Mozambique, Nigeria, Oman, Pakistan, Qatar, Rwanda, Sao Tome and Principe, Saudi Arabia, Sierra Leone, Somalia, Tanzania, Uganda, United Arab Emirates, West Bank/Gaza, Yemen, Zambia, and Zimbabwe: England
+
+In Liechtenstein: Switzerland
+
+In South Africa, Namibia, Lesotho, and Swaziland: the Republic of South Africa
+
+In United Kingdom: England
+
+In paragraph a, add the following at the end of the first sentence:
+
+In France: The Parties agree that articles 1222 and 1223 of the French Civil Code are not applicable.
+
+Add the following at the end of paragraph a:
+
+In Albania, Armenia, Azerbaijan, Belarus, Bosnia-Herzegovina, Bulgaria, Croatia, Former Yugoslav Republic of Macedonia, Georgia, Kazakhstan, Kosovo, Kyrgyzstan, Moldova, Montenegro, Romania, Russia, Serbia, Tajikistan, Turkmenistan, Ukraine, and Uzbekistan: All disputes arising out of this Agreement shall be finally settled by the International Arbitral Centre of the Austrian Federal Economic Chamber (Arbitration Body), under the Rules of Arbitration of that Arbitral Centre (Vienna Rules), in Vienna, Austria, with English as the official language, by three impartial arbitrators appointed in accordance with the Vienna Rules. Each party will nominate one arbitrator, who will jointly appoint an independent chairman within 30 days or else the chairman will be appointed by the Arbitration Body under the Vienna Rules. The arbitrators will have no authority to award injunctive relief or damages excluded by or exceeding limits in this Agreement. Nothing in this Agreement will prevent either party from resorting to judicial proceedings for (1) interim relief to prevent material prejudice or a breach of confidentiality provisions or intellectual property rights, or (2) determining the validity or ownership of any copyright, patent or trademark owned or asserted by a party or its Enterprise company, or (3) debt collection in amounts below USD 500,000.00.
+
+In Estonia, Latvia, and Lithuania: All disputes arising out of this Agreement shall be finally settled by the Arbitration Institute of the Finland Chamber of Commerce (FAI) (Arbitration Body), under the Arbitration Rules of the Finland Chamber of Commerce (Rules), in Helsinki, Finland, with English as the official language, by three impartial arbitrators appointed in accordance with those Rules. Each party will nominate one arbitrator, who will jointly appoint an independent chairman within 30 days or else the chairman will be appointed by the Arbitration Body under the Rules. The arbitrators will have no authority to award injunctive relief or damages excluded by or exceeding limits in this Agreement. Nothing in this Agreement will prevent either party from resorting to judicial proceedings for (1) interim relief to prevent material prejudice or a breach of confidentiality provisions or intellectual property rights, or (2) determining the validity or ownership of any copyright, patent or trademark owned or asserted by a party or its Enterprise company, or (3) debt collection in amounts below USD 500,000.00.
+
+In Afghanistan, Angola, Bahrain, Botswana, Burundi, Cape Verde, Djibouti, Egypt, Eritrea, Ethiopia, Gambia, Ghana, Iraq, Jordan, Kenya, Kuwait, Lebanon, Liberia, Libya, Madagascar, Malawi,, Mozambique, Nigeria, Oman, Pakistan, Palestinian Territory, Qatar, Rwanda, Sao Tome and Principe, Saudi Arabia, Seychelles, Sierra Leone, Somalia, South Sudan, Tanzania, Uganda, United Arab Emirates, Western Sahara, Yemen, Zambia, and Zimbabwe: All disputes arising out of this Agreement shall be finally settled by the London Court of International Arbitration (LCIA) (Arbitration Body), under the LCIA Arbitration Rules (the Rules), in London, UK, with English as the official language, by three impartial arbitrators appointed in accordance with the Rules. Each party will nominate one arbitrator, who will jointly appoint an independent chairman within 30 days or else the chairman will be appointed by the Arbitration Body under the Rules. The arbitrators will have no authority to award injunctive relief or damages excluded by or exceeding limits in this Agreement. Nothing in this Agreement will prevent either party from resorting to judicial proceedings for (1) interim relief to prevent material prejudice or a breach of confidentiality provisions or intellectual property rights, or (2) determining the validity or ownership of any copyright, patent or trademark owned or asserted by a party or its Enterprise company, or (3) debt collection in amounts below USD 500,000.00.
+
+In Algeria, Benin, Burkina Faso, Cameroon, Central African Republic, Chad, Congo Republic, Democratic Republic of Congo, Equatorial Guinea, French Guiana, French Polynesia, Gabon, Guinea, Guinea-Bissau, Ivory Coast, Mali, Mauritania, Mauritius, Morocco, Niger, Senegal, Togo, and Tunisia: All disputes arising out of this Agreement shall be finally settled by the ICC International Court of Arbitration, in Paris (Arbitration Body), under its arbitration rules (the Rules), in Paris, France, with French as the official language, by three impartial arbitrators appointed in accordance with the Rules. Each party will nominate one arbitrator, who will jointly appoint an independent chairman within 30 days or else the chairman will be appointed by the Arbitration Body under the Rules. The arbitrators will have no authority to award injunctive relief or damages excluded by or exceeding limits in this Agreement. Nothing in this Agreement will prevent either party from resorting to judicial proceedings for (1) interim relief to prevent material prejudice or a breach of confidentiality provisions or intellectual property rights, or (2) determining the validity or ownership of any copyright, patent or trademark owned or asserted by a party or its Enterprise company, or (3) debt collection in amounts below USD 250,000.00.
+
+In South Africa, Namibia, Lesotho, and Swaziland: All disputes arising out of this Agreement shall be finally settled by the Arbitration Foundation of Southern Africa (AFSA) (Arbitration Body), under the Rules of the Arbitration of the AFSA (the Rules), in Johannesburg, South Africa, with English as the official language, by three impartial arbitrators appointed in accordance with the Rules. Each party will nominate one arbitrator, who will jointly appoint an independent chairman within 30 days or else the chairman will be appointed by the Arbitration Body under the Rules. The arbitrators will have no authority to award injunctive relief or damages excluded by or exceeding limits in this Agreement. Nothing in this Agreement will prevent either party from resorting to judicial proceedings for (1) interim relief to prevent material prejudice or a breach of confidentiality provisions or intellectual property rights, or (2) determining the validity or ownership of any copyright, patent or trademark owned or asserted by a party or its Enterprise company, or (3) debt collection in amounts below USD 250,000.00.
+
+In Andorra, Austria, Cyprus, France, Germany, Greece, Israel, Italy, Portugal, Spain, Switzerland, and Turkey: All disputes will be brought before and subject to the exclusive jurisdiction of the following court of competent jurisdiction:
+
+In Andorra: the Commercial Court of Paris.
+
+In Austria: the court of Vienna, Austria (Inner City).
+
+In Cyprus: the competent court of Nicosia.
+
+In France: Commercial Court of Paris.
+
+In Germany: the courts of Stuttgart.
+
+In Greece: the competent court of Athens.
+
+In Israel: the courts of Tel Aviv Jaffa.
+
+In Italy: the courts of Milan.
+
+In Portugal: the courts of Lisbon.
+
+In Spain: the courts of Madrid.
+
+In Switzerland: the commercial court of the canton of Zurich.
+
+In Turkey: the Istanbul Central (Caglayan) Courts and Execution Directorates of Istanbul, the Republic of Turkey.
+
+In Netherlands: The Parties waive their rights under Title 7.1 ('Koop') and clause 7:401 and 402 of the Dutch Civil Code, and their rights to invoke a full or partial dissolution ('gehele of partiele ontbinding') of this Agreement under section 6:265 of the Dutch Civil Code.
+
+Section 7. General
+
+In paragraph d, insert the following at the end of the paragraph:
+
+In Spain: IBM will comply with requests to access, update or delete contact information if submitted to the following address: IBM, c/ Santa Hortensia 26-28, 28002 Madrid, Departamento de Privacidad de Datos.
+
+In paragraph j, add to the end the paragraph:
+
+In Czech Republic: Pursuant to Section 1801 of Act No. 89/2012 Coll. (the "Civil Code"), Section 1799 and Section 1800 of the Civil Code as amended, do not apply to transactions under this Agreement. Licensee accepts the risk of a change of circumstances under Section 1765 of the Civil Code.
+
+In paragraph j:
+
+In Bulgaria, Croatia, Russia, Serbia, and Slovenia: delete the 2nd sentence that says: "Neither party will bring a legal action arising out of or related to the Agreement more than two years after the cause of action arose".
+
+In paragraph j, add to the end of the second sentence:
+
+In Lithuania: , except as provided by law
+
+In paragraph j, replace the second sentence with:
+
+In Poland: Neither party will bring a legal action arising out of or related to the Agreement more than three years after the cause of action arose, except for an action of non-payment which will be brought no more than 2 years after payment is due.
+
+In paragraph j, second sentence, replace the word "two" with:
+
+In Latvia and Ukraine: three
+
+In Slovakia: four
+
+In paragraph j, add to the end of the third sentence that says: "Neither party is responsible for failure to fulfill its non-monetary obligations due to causes beyond its control":
+
+In Russia: , including but not limited to earthquakes, floods, fires, acts of God, strikes (excluding strikes of the parties' employees), acts of war, military actions, embargoes, blockades, international or governmental sanctions, and acts of authorities of the applicable jurisdiction.
+
+In paragraph j, third sentence, modify the sentence: "Neither party is responsible for failure to fulfill its non-monetary obligations due to causes beyond its control" as follows:
+
+In Ukraine: Neither party is responsible for failure to fulfill its non-monetary obligations due to causes or regulatory changes beyond its control, including but not limited to import, export and economic sanctions requirements of the United States.
+
+Add the following at the end of the section as new paragraph l:
+
+In Hungary: By entering into this Agreement, Licensee confirms that Licensee was sufficiently informed of all the provisions of this Agreement and had the opportunity to negotiate those terms. The following provisions may significantly deviate from the provisions generally applied by Hungarian law and both parties accept those provisions by signing the Agreement: Program License; Warranties; Charges, Taxes, Payment, and Verification; Liability and Intellectual Property Protection; Termination; Governing Laws and Geographic Scope; and General.
+
+In Czech Republic: Licensee expressly accepts the terms of this agreement which include the following important commercial terms: i) limitation and disclaimer of liability for defects (Warranties); ii) limitation of Licensee's entitlement to damages (Liability and Intellectual Property Protection); iii) binding nature of export and import regulations (Governing Laws and Geographic Scope); iv) shorter limitation periods (General); v) exclusion of applicability of provisions on adhesion contracts (General); and vi) acceptance of the risk of a change of circumstances (General).
+
+In Romania: The Licensee expressly accepts, the following standard clauses that may be deemed 'unusual clauses' as per the provisions of article 1203 Romanian Civil Code: clauses 2, 4, 5, 8j. The Licensee hereby acknowledges that it was sufficiently informed of all the provisions of this Agreement, including the clauses mentioned above, it properly analyzed and understood such provisions and had the opportunity to negotiate the terms of each clause.
+
+i125-3301-15 (10-2021)
+
+-----
+
+LICENSE INFORMATION
+
+The Programs listed below are licensed under the following License Information terms and conditions in addition to the Program license terms previously agreed to by Client and IBM. If Client does not have previously agreed to license terms in effect for the Program, the International License Agreement for Evaluation of Programs (i125-5543-06) applies.
+
+Program Name (Program Number):
+IBM Watson Speech to Text Library for Embed 1.0.0 (Evaluation)
+
+The following standard terms apply to Licensee's use of the Program.
+
+Evaluation Period
+
+The evaluation period begins on the date that Licensee agrees to the terms of this Agreement and ends after 180 days.
+
+Modifiable Third Party Code
+
+To the extent, if any, in the NOTICES file IBM identifies third party code as "Modifiable Third Party Code," IBM authorizes Licensee to 1) modify the Modifiable Third Party Code and 2) reverse engineer the Program modules that directly interface with the Modifiable Third Party Code provided that it is only for the purpose of debugging Licensee's modifications to such third party code. IBM's service and support obligations, if any, apply only to the unmodified Program.
+
+Separately Licensed Code
+
+Each of the components listed in the NON_IBM_LICENSE file is considered "Separately Licensed Code" licensed to Licensee under the terms of the applicable third party license agreement(s) set forth in the NON_IBM_LICENSE file(s) that accompanies the Program, and not this Agreement. Future Program updates or fixes may contain additional Separately Licensed Code. Such additional Separately Licensed Code and related licenses are listed in the applicable NON_IBM_LICENSE file that accompanies the Program update or fix.
+
+Note: Notwithstanding any of the terms in the third party license agreement, the Agreement, or any other agreement Licensee may have with IBM, with respect to the Separately Licensed Code:
+(a) IBM provides it to Licensee WITHOUT WARRANTIES OF ANY KIND AND DISCLAIMS ANY AND ALL EXPRESS AND IMPLIED WARRANTIES AND CONDITIONS INCLUDING, BUT NOT LIMITED TO, THE WARRANTY OF TITLE, NON-INFRINGEMENT OR NON-INTERFERENCE, AND THE IMPLIED WARRANTIES AND CONDITIONS OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE;
+(b) IBM is not liable for any direct, indirect, incidental, special, exemplary, punitive or consequential damages including, but not limited to, lost data, lost savings, and lost profits.
+
+Benchmarking
+
+Licensee may disclose the results of any benchmark test of the Program or its subcomponents to any third party provided that Licensee (A) publicly discloses the complete methodology used in the benchmark test (for example, hardware and software setup, installation procedure and configuration files), and (B) performs testing running the Program in its Specified Operating Environment using the latest applicable updates, patches, fixes, performance tuning, and best practices guidance available for the Program,. If Licensee publishes the results of any benchmark tests for the Program, then IBM (including third parties providing IBM products "Third Parties") will have the right to publish the results of benchmark tests with respect to Licensee's products provided IBM or Third Parties complies with the requirements of (A), and (B) above in its testing of Licensee's products.
+
+Notwithstanding the foregoing, under no circumstances may Licensee publish the results of benchmark tests run on Oracle Outside In Technology without prior written permission.
+
+L/N:  L-DAJI-CJULKJ
+D/N:  L-DAJI-CJULKJ
+P/N:  L-DAJI-CJULKJ
+
+
+
+-----
+
+International License Agreement for Evaluation of Programs
+
+Part 1 - General Terms
+
+BY DOWNLOADING, INSTALLING, COPYING, ACCESSING, CLICKING ON AN "ACCEPT" BUTTON, OR OTHERWISE USING THE PROGRAM, LICENSEE AGREES TO THE TERMS OF THIS AGREEMENT. IF YOU ARE ACCEPTING THESE TERMS ON BEHALF OF LICENSEE, YOU REPRESENT THAT YOU HAVE FULL AUTHORITY TO BIND LICENSEE TO THESE TERMS.
+
+IF YOU DO NOT AGREE TO THESE TERMS OR DO NOT HAVE AUTHORITY: i) DO NOT DOWNLOAD, INSTALL, COPY, ACCESS, CLICK ON AN "ACCEPT" BUTTON, OR USE THE PROGRAM; AND ii) PROMPTLY RETURN THE UNUSED MEDIA, DOCUMENTATION, AND PROOF OF ENTITLEMENT TO THE PARTY FROM WHOM IT WAS OBTAINED FOR A REFUND OF THE AMOUNT PAID. IF THE PROGRAM WAS DOWNLOADED, DESTROY ALL COPIES OF THE PROGRAM.
+
+This International License Agreement for Evaluation of Programs (ILAE) and applicable Transaction Documents (together the "Agreement") are the complete agreement between Licensee and IBM regarding the use of a Program. The country required terms included in Part 2 of this ILAE replace or modify the terms of Part 1.
+
+Transaction Documents (TDs) provide a description, information, and terms regarding the Program and its authorized use. Examples of TDs for Programs include license information (LI), licensed program specifications (LPS), quote, proof of entitlement (PoE), or invoice. To the extent of any conflict a TD will prevail over the ILAE.
+
+1. Program License
+
+a. A Program is an executable IBM-branded computer program and its related material and includes whole and partial copies. Program details are described in a TD available at http://www.ibm.com/software/sla (for Passport Advantage Programs) or http://www.ibm.com/support/knowledgecenter (for other IBM Programs), in the Program's system command directory, or as otherwise specified by IBM. IBM software policies (such as backup, temporary use and IBM approved cloud environment) available at http://www.ibm.com/softwarepolicies apply to Licensee's use of Programs.
+
+b. Copies of Programs are copyrighted and licensed.
+
+c. Licensee is granted a nonexclusive limited license to:
+
+(1) use each copy of a Program solely for internal evaluation, testing, or demonstration purposes on a trial basis during the Evaluation Period (as defined in the applicable Program TD) ("Authorized Use");
+
+(2) make and install copies to support such Authorized Use; and
+
+(3) make a backup copy.
+
+d. Programs may be used by Licensee, its employees and contractors. Licensee may not use the Program for productive purposes, rent or lease a Program, or provide commercial IT, hosting or timesharing services to any third party. Additional rights may be available for additional fees or under different terms.
+
+e. The license granted for a Program is subject to Licensee:
+
+(1) reproducing copyright notices and other markings on any copy;
+
+(2) ensuring anyone who uses the Program: i) does so only on Licensee's behalf within Licensee's Authorized Use; and ii) complies with this Agreement;
+
+(3) not disabling any disabling device, reverse assembling, reverse compiling, translating, or reverse engineering the Program, except as expressly permitted by law without the possibility of contractual waiver; and
+
+(4) not using any of the elements of the Program or related licensed materials separately from the Program.
+
+f. If the TD for a Program ("Principal Program") states that a "Supporting Program" is included with the Principal Program, Licensee may use the Supporting Program subject to any license limitations of the Principal Program and only to support the Principal Program.
+
+g. This license applies to each copy of the Program that Licensee makes.
+
+h. An update, fix, or patch to a Program is subject to the terms governing the Program unless new terms are provided in an updated TD. Licensee accepts such new terms upon installation of the update, fix, or patch. If a Program is replaced by an update, Licensee agrees to promptly discontinue use of the replaced Program.
+
+2. Warranties
+
+a. Subject to applicable laws, Programs are provided as-is, with no warranties of any kind, including: i) no warranty for uninterrupted or error-free operation of the Program; or ii) no other warranties such as implied warranties or conditions of satisfactory quality, merchantability, non-infringement, and fitness for a particular purpose.
+
+b. IBM does not provide any support, unless otherwise specified in a TD.
+
+3. Charges, Taxes, Payment, and Verification
+
+a. There are no charges for use of a Program during the Evaluation Period, unless specified otherwise by IBM. If any authority imposes a custom, duty, tax (including withholding tax), levy or fee for the import or export, transfer, access or use of the Program, then Licensee is responsible to pay any such amount imposed.
+
+b. If Licensee imports, exports, transfers, accesses, or uses a Program across a border, Licensee agrees to be responsible for and pay authorities any custom, duty, tax, or similar levy assessed by the authorities. This excludes those taxes based on IBM's net income.
+
+3.1 Licensing Verification
+
+a. Licensee will, for all Programs at all sites and for all environments, create, retain, and provide to IBM upon request with 30 days' advance notice: i) a report, in a format requested by IBM using records, system tools output, and other system information; and ii) supporting documentation (collectively, "Deployment Data").
+
+b. Upon reasonable notice, IBM and its independent auditors may verify Licensee's compliance with this Agreement, at all sites and for all environments in which Licensee uses (for any purposes) Programs. Verification will be conducted in a manner that minimizes disruption to Licensee's business and may be conducted on Licensee's premises, during normal business hours. IBM will have a written confidentiality agreement with the independent auditor. In addition to providing Deployment Data described above, Licensee agrees to provide to IBM and its auditors additional accurate information and Deployment Data upon request.
+
+c. Licensee will promptly order and pay charges at IBM's then current rates associated with: i) any deployments or use in excess of authorizations or in violation of this agreement indicated on or by any verification; ii) applicable subscription & support services (S&S) for such excess deployments for the lesser of the duration of such excess use or two years; and iii) any additional charges and other liabilities determined as a result of such verification, including but not limited to taxes, duties, and regulatory fees.
+
+4. Liability
+
+a. IBM's entire liability for all claims related to the Agreement will not exceed the amount of any actual direct damages incurred by Licensee up to the greater of: i) U.S. $10,000.00 (or equivalent in local currency); or ii) the amounts paid (if recurring charges, up to 12 months' charges apply) for the entitlements to the Program that is the subject of the claim, regardless of the basis of the claim. IBM will not be liable for special, incidental, exemplary, indirect, or economic consequential damages, or for lost profits, business, value, revenue, goodwill, or anticipated savings. These limitations apply collectively to IBM, its affiliates, contractors, and suppliers.
+
+b. The following amounts are not subject to the above cap: damages that cannot be limited under applicable law.
+
+c. IBM has no responsibility for claims based on non-IBM products, items not provided by IBM, or any violation of law or third party rights caused by Content, or any Licensee materials, designs, specifications. Content consists of all data, software, and information that Licensee or its authorized users provide, authorize access to, or inputs to a Program.
+
+5. Termination
+
+a. The Evaluation Period begins on the date Licensee agrees to the terms of this Agreement and ends upon the earliest of: i) the date specified in the applicable TD; or ii) the date on which the Program automatically disables itself. Licensee will destroy the Program and all copies made of it within ten days of the end of the Evaluation Period. Licensee is responsible to remove any Content prior to expiration of the Evaluation Period as any disabling device may prevent use upon expiration.
+
+b. If IBM specifies in a TD that Licensee may retain the Program, and Licensee elects to do so, then the Program will be subject to a different license agreement, which IBM will provide to Licensee. In addition, a charge may apply.
+
+c. IBM may terminate Licensee's license to use a Program if Licensee fails to comply with the ILAE, TDs or acquisition agreements, such as the International Passport Advantage Agreement (IPAA). Licensee will promptly destroy all copies of the Program after license termination. Any terms that by their nature extend beyond the termination remain in effect until fulfilled and apply to successors and assignees.
+
+6. Governing Laws and Geographic Scope
+
+a. Both parties agree to the application of the laws of the country where the transaction for license entitlements is performed, without regard to conflict of law principles. The rights and obligations of each party are valid only in the country where the transaction to acquire license entitlements is performed or, if IBM agrees, the country where the Program is placed in productive use, except all licenses are valid as specifically granted.
+
+b. Each party is also responsible for complying with: i) laws and regulations applicable to its business and Content; and ii) import, export and economic sanction laws and regulations, including the defense trade control regime of the United States of America and any applicable jurisdictions, that prohibit or restrict the import, export, re-export, or transfer of products, technology, services or data, directly or indirectly, to or for certain countries, end uses or end users.
+
+c. If any provision of this Agreement for a Program, is invalid or unenforceable, the remaining provisions remain in full force and effect. Nothing in this Agreement affects statutory rights of consumers that cannot be waived or limited by contract. The United Nations Convention on Contracts for the International Sale of Goods does not apply to transactions under this Agreement.
+
+7. General
+
+a. IBM is an independent contractor, not Licensee's agent, joint venturer, partner, or fiduciary, and does not undertake to perform any of Licensee's regulatory obligations, or assume any responsibility for Licensee's business or operations. Licensee is responsible for its use of IBM Programs and Non-IBM Programs. IBM is acting as an information technology provider only. IBM's direction, suggested usage, or guidance or use of a Program does not constitute medical, clinical, legal, accounting, or other licensed professional advice. Licensee should obtain its own expert advice.
+
+b. For Programs IBM provides to Licensee in tangible form, IBM fulfills its shipping and delivery obligations upon the delivery of such Programs to the IBM-designated carrier, unless otherwise agreed to in writing by Licensee and IBM.
+
+c. Licensee may not use the Program if failure of the Program could lead to death, serious bodily injury, or property or environmental damage.
+
+d. IBM, its affiliates, and contractors of either require use of business contact information and certain account usage information. This information is not Content. Business contact information is used to communicate and manage business dealings with the Licensee. Examples of business contact information include name, business telephone, address, email, user ID, and tax registration information. Account usage information is required to enable, provide, manage, support, administer, and improve Programs. Examples of account usage information include reported errors and digital information gathered using tracking technologies, such as cookies and web beacons, during use of the Programs. The IBM Privacy Statement at https://www.ibm.com/privacy/ provides additional details with respect to IBM's collection, use, and handling of business contact and account usage information. When Licensee provides information to IBM and notice to, or consent by, the individuals is required for such processing, Licensee will notify individuals and obtain consent.
+
+e. IBM Business Partners who use or make available Programs are independent from IBM and unilaterally determine their prices and terms. IBM is not responsible for their actions, omissions, statements, or offerings.
+
+f. IBM may offer Non-IBM Programs, or an IBM Program may enable access to Non-IBM Programs, that may require acceptance of third party terms identified in a TD or presented to the Licensee. Linking to or use of Non-IBM Programs constitutes Licensee's agreement with such terms. IBM is not a party to such third party agreements and is not responsible for such Non-IBM Programs.
+
+g. License grants to Programs are provided by International Business Machines Corporation, a New York corporation ("IBM Corporation"). The IBM company from which the Licensee acquires entitlements ("IBM") is acting as a distributor and delivering Programs and is responsible for enforcing the terms of this Agreement. If entitlements are acquired from an IBM Business Partner, the IBM company for the country of acquisition is responsible for enforcing the terms of this Agreement. No right or cause of action is created in favor of Licensee against IBM Corporation. Licensee waives all claims and causes of action against IBM Corporation and agrees to look solely to IBM for any rights and remedies in connection with Programs.
+
+h. Licensee may not sublicense, assign, or transfer the license for any Program (except to the extent assignment or transfer may not be legally restricted or as is expressly permitted in a TD or as otherwise agreed by IBM). IBM may assign its rights and obligations under this Agreement in conjunction with the sale of the portion of IBM's business that includes a Program. IBM may share this Agreement and related documents in conjunction with any assignment.
+
+i. All notices under the Agreement must be in writing and sent to the business address specified in the agreement Licensee acquired the license entitlements unless a party designates in writing a different address. The parties consent to the use of electronic means and facsimile transmissions for communications as a signed writing. Any reproduction of the Agreement made by reliable means is considered an original. Agreement supersedes any course of dealing, discussions or representations, between the parties.
+
+j. No right or cause of action for any third party is created by the Agreement. Neither party will bring a legal action arising out of or related to the Agreement more than two years after the cause of action arose. Neither party is responsible for failure to fulfill its non-monetary obligations due to causes beyond its control. Each party will allow the other reasonable opportunity to comply before it claims the other has not met its obligations.
+
+k. IBM may use personnel and resources in locations worldwide, including third party contractors to support the delivery of Programs and Program support. Licensee's use of Programs may result in the transfer of Content, including personally identifiable information, across country borders to provide Program support as described in the IBM Software Support Guide.
+
+Part 2 - Country Required Terms
+
+For licenses acquired in the countries specified below, the following terms replace or modify the referenced terms of this ILAE. Terms not changed by these amendments remain unchanged and in effect.
+
+1. AMERICAS
+
+Section 4. Liability
+
+Insert the following disclaimer at the end of paragraph a:
+
+In Peru: In accordance with Article 1328 of the Peruvian Civil Code this limitations and exclusions will not apply in the cases of willful misconduct ("dolo") or gross negligence ("culpa inexcusable").
+
+Section 6. Governing Laws and Geographic Scope
+
+In paragraph a, replace the first sentence only with:
+
+In Argentina: Both parties agree to the application of the laws of the Republic of Argentina, without regard to the conflict of law principles. Any proceeding regarding the rights, duties, and obligations arising from this Agreement will be brought in the Ordinary Commercial Court of the City of "Ciudad Autónoma de Buenos Aires".
+
+In Chile: Both parties agree to the application of the laws of Chile, without regard to the conflict of law principles. Any conflict, interpretation or breach related to this Agreement that cannot be solved by the Parties should be remitted to the jurisdiction of the Ordinary Courts of the city and district of Santiago.
+
+In Colombia: Both parties agree to the application of the laws of the Republic of Colombia, without regard to the conflict of law principles. All rights, duties and obligations are subject to the judges of the Republic of Colombia.
+
+In Ecuador: Both parties agree to the application of the laws of the Republic of Ecuador, without regard to the conflict of law principles. Any dispute arising out or relating to this Agreement will be submitted to the civil judges of Quito and to the verbal summary proceeding.
+
+In Venezuela: Both parties agree to the application of the laws of Venezuela, without regard to the conflict of law principles. The parties agree to submit any conflict related to this Agreement, existing between them to the Courts of the Metropolitan Area of the City of Caracas.
+
+In Peru: Both parties agree to the application of the laws of Peru, without regard to the conflict of law principles. Any discrepancy that may arise between the parties in the execution, interpretation or compliance of this Agreement that may not be directly resolved shall be submitted to the Jurisdiction and Competence of the Judges and Tribunals of the 'Cercado de Lima' Judicial District.
+
+In Uruguay: Both parties agree to the application of the laws of Uruguay. Any discrepancy that may arise between the parties in the execution, interpretation or compliance of this Agreement that may not be directly resolved shall be submitted to the Montevideo Courts ("Tribunales Ordinarios de Montevideo").
+
+In paragraph a, first sentence only, replace the phrase, "the country where the transaction for license entitlements is performed" with:
+
+In United States, Anguilla, Antigua/Barbuda, Aruba, Bahamas, Barbados, Bermuda, Bonaire, British Virgin Islands, Cayman Islands, Curacao, Dominica, Grenada, Guyana, Jamaica, Montserrat, Saba, Saint Eustatius, Saint Kitts and Nevis, Saint Lucia, Saint Maarten, Saint Vincent and the Grenadines, Suriname, Tortola, Trinidad and Tobago, and Turk and Caicos: the State of New York, United States.
+
+In Canada: the Province of Ontario and the federal laws of Canada applicable therein.
+
+In paragraph a, second sentence, replace the phrase, "the country where the transaction to acquire license entitlements is performed " with:
+
+In Argentina: Argentina
+
+In Chile: Chile
+
+In Colombia: Colombia
+
+In Ecuador: Ecuador
+
+In Mexico: Mexico
+
+In Peru: Peru
+
+In Uruguay: Uruguay
+
+In Venezuela: Venezuela
+
+Add the following sentences at the end of paragraph b:
+
+In Brazil: All disputes arising out of or related to this Agreement, including summary proceedings, will be brought before and subject to the exclusive jurisdiction of the Forum of the City of São Paulo, State of São Paulo, Brazil and the parties irrevocably agree with this specific jurisdiction renouncing any other, however privileged it may be.
+
+In Mexico: The Parties agree to submit themselves to the exclusive jurisdiction of the courts of Mexico City to resolve any dispute arising from this Agreement. The Parties waive to any other jurisdiction that may correspond to them due to their current or future domiciles, or for any other reason.
+
+Section 7. General
+
+In paragraph g:
+
+In United States: delete the last 2 sentences.
+
+In paragraph i, add the following new sentence after the first sentence:
+
+In Mexico: Any change of address must be notified 10 (ten) days in advance, otherwise the notifications made at the last indicated address will have full legal effects.
+
+In paragraph j:
+
+In Brazil: delete the entire 2nd sentence of "Neither party will bring a legal action arising out of or related to the Agreement more than two years after the cause of action arose".
+
+Add as a new paragraph l to this section:
+
+In Canada: Both parties agree to write this document in English. Les parties ont convenu de rédiger le présent document en langue anglaise.
+
+2. ASIA PACIFIC
+
+Section 2. Warranties
+
+Add at the end of this section as a new paragraph c:
+
+In Australia: These warranties are in addition to any rights under, and only limited to the extent permitted by, the Competition and Consumer Act 2010.
+
+In Japan: IBM's liability is limited to this paragraph and the Liability section, applicable TDs as Licensee's sole remedy for failure to meet the warranties specified in this section.
+
+In New Zealand: These warranties are in addition to any rights under the Consumer Guarantee Act 1993 or other legislation that cannot be limited by law.
+
+Section 4. Liability
+
+In paragraph a, add at the end of the first sentence the following:
+
+In Australia: (for example, whether based in contract, tort, negligence, under statute or otherwise)
+
+In paragraph a, second sentence after the word "special" and before the word "incidental", add the following:
+
+In Philippines: (including nominal and exemplary damages), moral,
+
+Section 5. Termination
+
+Add at the end of the section as a new paragraph d:
+
+In Indonesia: The parties waive article 1266 of the Indonesian Civil Code to the extent it requires a court decree for the termination of an agreement creating mutual obligations.
+
+Section 6. Governing Laws and Geographic Scope
+
+In paragraph a, in the first sentence only, replace the phrase, "the country where the transaction for license entitlements is performed" with:
+
+In Cambodia, Laos: the State of New York, United States
+
+In Australia: the State or Territory in which the transaction is performed
+
+In Hong Kong: the Hong Kong Special Administrative Region of the People's Republic of China
+
+In Macau: the Hong Kong Special Administrative Region of the People's Republic of China
+
+In Korea: the Republic of Korea, and subject to the Seoul Central District Court of the Republic of Korea
+
+In Taiwan: Taiwan
+
+In India: India
+
+In paragraph b, in the first sentence, item ii), after the word "including" and before word "defense", add:
+
+In Japan: those of Japan laws and
+
+In paragraph a, in the second sentence, replace the phrase "the country where the transaction to acquire license entitlements is performed or, if IBM agrees, the country where the Program is placed in productive use" with:
+
+In Hong Kong: the Hong Kong Special Administrative Region of the People's Republic of China
+
+In Macau: the Macau Special Administrative Region of the People's Republic of China
+
+In Taiwan: Taiwan
+
+Add at the end of the section as a new paragraph d:
+
+In Cambodia, Laos, Philippines, and Sri Lanka: Disputes will be finally settled by arbitration in Singapore under the Arbitration Rules of the Singapore International Arbitration Center ("SIAC Rules").
+
+In India: Disputes shall be finally settled in accordance with The Arbitration and Conciliation Act, 1996 then in effect, in English, with seat in Bangalore, India. There shall be one arbitrator if the amount in dispute is less than or equal to Indian Rupee five crores and three arbitrators if the amount is more. When an arbitrator is replaced, proceedings shall continue from the stage they were at when the vacancy occurred.
+
+In Indonesia: Disputes will be finally settled by arbitration in Jakarta, Indonesia, administered by the Indonesian National Board of Arbitration established in the year 1977 ("Badan Arbitrase Nasional Indonesia" or "BANI") in accordance with the rules of the Indonesian National Board of Arbitration The arbitration award shall be final and binding on the parties without appeal and shall be in writing and set forth the findings of fact and the conclusion of law.
+
+In People's Republic of China: Either party has the right to submit the dispute to the China International Economic and Trade Arbitration Commission in Beijing, the PRC, for arbitration. The parties agree three arbitrators will be used to resolve any dispute.
+
+In Vietnam: Disputes will be finally settled by arbitration in Vietnam under the Arbitration Rules of the Vietnam International Arbitration Centre ("VIAC Rules"). All proceedings and documents presented will be in the English language.
+
+Section 7. General
+
+In paragraph j, in the second sentence, replace the phrase "two years" with:
+
+In India: three years
+
+Add to the end of this section the following new paragraph l:
+
+In Indonesia: This agreement is made in the English and Bahasa Indonesian language versions. To the extent permitted by the applicable law, the English version will prevail in the event of conflict between such versions.
+
+3. EUROPE, MIDDLE EAST, AND AFRICA
+
+Section 4. Liability
+
+In paragraph a, in the first sentence insert the following before the words "the amounts paid":
+
+In Belgium, France, Germany, Italy, Luxembourg, Malta, Portugal, and Spain: the greater of €500,000 (five hundred thousand euro) or
+
+In Ireland and United Kingdom: 125% of
+
+In paragraph a, in the first sentence, replace the phrase "direct damages incurred by Licensee" with:
+
+In Spain: and proven damages incurred by Licensee as a direct consequence of the IBM default
+
+In paragraph a, insert after the first sentence the following new sentence:
+
+In Slovakia: Referring to § 379 of the Commercial Code, Act No. 513/1991 Coll. as amended, and concerning all conditions related to the conclusion of the agreement, both parties state that the total foreseeable damage, which may accrue, shall not exceed the amount above, and it is the maximum for which IBM is responsible.
+
+In paragraph a, insert before the second sentence the following new sentence:
+
+In Russia: IBM will not be liable for the forgone benefit.
+
+In paragraph a, in the second sentence, delete the word:
+
+In Ireland and United Kingdom: economic
+
+In paragraph a, replace the second sentence with:
+
+In Belgium, Netherlands, and Luxembourg: IBM will not be liable for indirect or consequential damages, lost profits, business, value, revenue, goodwill, damage to reputation or anticipated savings, any third party claim against Licensee, and loss of (or damage to) data.
+
+In France: IBM will not be liable for damages to reputation, indirect damages, or lost profits, business, value, revenue, goodwill, or anticipated savings.
+
+In Portugal: IBM will not be liable for indirect damages, including loss of profit.
+
+In Spain: IBM will not be liable for damage to reputation, lost profits, business, value, revenue, goodwill, or anticipated savings.
+
+Add the following at the end of paragraph a:
+
+In France: The terms of the Agreement, including financial terms, were established in consideration of the present clause, which is an integral part of the general economy of the Agreement.
+
+In paragraph b, replace "damages that cannot be limited under applicable law" with the following:
+
+In Germany: i) damages for body injury (including death); ii) loss or damage caused by a breach of guarantee assumed by IBM in connection with any transaction under this Agreement; and iii) caused intentionally or by gross negligence.
+
+Section 6. Governing Laws and Geographic Scope
+
+In paragraph a, first sentence only, replace the phrase "the country where the transaction for license entitlements is performed" with:
+
+In Albania, Armenia, Azerbaijan, Belarus, Bosnia-Herzegovina, Bulgaria, Croatia, Former Yugoslav Republic of Macedonia, Georgia, Kazakhstan, Kyrgyzstan, Moldova, Montenegro, Romania, Russia, Serbia, Tajikistan, Turkmenistan, Ukraine, and Uzbekistan: Austria
+
+In Estonia, Latvia, and Lithuania: Finland
+
+In Algeria, Andorra, Benin, Burkina Faso, Burundi, Cameroon, Cape Verde, Central African Republic, Chad, Comoros, Congo Republic, Djibouti, Democratic Republic of Congo, Equatorial Guinea, French Guiana, French Polynesia, Gabon, Guinea, Guinea-Bissau, Ivory Coast, Lebanon, Madagascar, Mali, Mauritania, Mauritius, Mayotte, Morocco, New Caledonia, Niger, Reunion, Senegal, Seychelles, Togo, Tunisia, Vanuatu, and Wallis and Futuna: France
+
+In Angola, Bahrain, Botswana, Egypt, Eritrea, Ethiopia, Gambia, Ghana, Iraq, Jordan, Kenya, Kuwait, Liberia, Malawi, Malta, Mozambique, Nigeria, Oman, Pakistan, Qatar, Rwanda, Sao Tome and Principe, Saudi Arabia, Sierra Leone, Somalia, Tanzania, Uganda, United Arab Emirates, West Bank/Gaza, Yemen, Zambia, and Zimbabwe: England
+
+In Liechtenstein: Switzerland
+
+In South Africa, Namibia, Lesotho, and Swaziland: the Republic of South Africa
+
+In United Kingdom: England
+
+In paragraph a, add the following at the end of the first sentence:
+
+In France: The Parties agree that articles 1222 and 1223 of the French Civil Code are not applicable.
+
+Add the following at the end of paragraph a:
+
+In Albania, Armenia, Azerbaijan, Belarus, Bosnia-Herzegovina, Bulgaria, Croatia, Former Yugoslav Republic of Macedonia, Georgia, Kazakhstan, Kosovo, Kyrgyzstan, Moldova, Montenegro, Romania, Russia, Serbia, Tajikistan, Turkmenistan, Ukraine, and Uzbekistan: All disputes arising out of this Agreement shall be finally settled by the International Arbitral Centre of the Austrian Federal Economic Chamber (Arbitration Body), under the Rules of Arbitration of that Arbitral Centre (Vienna Rules), in Vienna, Austria, with English as the official language, by three impartial arbitrators appointed in accordance with the Vienna Rules. Each party will nominate one arbitrator, who will jointly appoint an independent chairman within 30 days or else the chairman will be appointed by the Arbitration Body under the Vienna Rules. The arbitrators will have no authority to award injunctive relief or damages excluded by or exceeding limits in this Agreement. Nothing in this Agreement will prevent either party from resorting to judicial proceedings for (1) interim relief to prevent material prejudice or a breach of confidentiality provisions or intellectual property rights, or (2) determining the validity or ownership of any copyright, patent or trademark owned or asserted by a party or its Enterprise company, or (3) debt collection in amounts below USD 500,000.00.
+
+In Estonia, Latvia, and Lithuania: All disputes arising out of this Agreement shall be finally settled by the Arbitration Institute of the Finland Chamber of Commerce (FAI) (Arbitration Body), under the Arbitration Rules of the Finland Chamber of Commerce (Rules), in Helsinki, Finland, with English as the official language, by three impartial arbitrators appointed in accordance with those Rules. Each party will nominate one arbitrator, who will jointly appoint an independent chairman within 30 days or else the chairman will be appointed by the Arbitration Body under the Rules. The arbitrators will have no authority to award injunctive relief or damages excluded by or exceeding limits in this Agreement. Nothing in this Agreement will prevent either party from resorting to judicial proceedings for (1) interim relief to prevent material prejudice or a breach of confidentiality provisions or intellectual property rights, or (2) determining the validity or ownership of any copyright, patent or trademark owned or asserted by a party or its Enterprise company, or (3) debt collection in amounts below USD 500,000.00.
+
+In Afghanistan, Angola, Bahrain, Botswana, Burundi, Cape Verde, Djibouti, Egypt, Eritrea, Ethiopia, Gambia, Ghana, Iraq, Jordan, Kenya, Kuwait, Lebanon, Liberia, Libya, Madagascar, Malawi,, Mozambique, Nigeria, Oman, Pakistan, Palestinian Territory, Qatar, Rwanda, Sao Tome and Principe, Saudi Arabia, Seychelles, Sierra Leone, Somalia, South Sudan, Tanzania, Uganda, United Arab Emirates, Western Sahara, Yemen, Zambia, and Zimbabwe: All disputes arising out of this Agreement shall be finally settled by the London Court of International Arbitration (LCIA) (Arbitration Body), under the LCIA Arbitration Rules (the Rules), in London, UK, with English as the official language, by three impartial arbitrators appointed in accordance with the Rules. Each party will nominate one arbitrator, who will jointly appoint an independent chairman within 30 days or else the chairman will be appointed by the Arbitration Body under the Rules. The arbitrators will have no authority to award injunctive relief or damages excluded by or exceeding limits in this Agreement. Nothing in this Agreement will prevent either party from resorting to judicial proceedings for (1) interim relief to prevent material prejudice or a breach of confidentiality provisions or intellectual property rights, or (2) determining the validity or ownership of any copyright, patent or trademark owned or asserted by a party or its Enterprise company, or (3) debt collection in amounts below USD 500,000.00.
+
+In Algeria, Benin, Burkina Faso, Cameroon, Central African Republic, Chad, Congo Republic, Democratic Republic of Congo, Equatorial Guinea, French Guiana, French Polynesia, Gabon, Guinea, Guinea-Bissau, Ivory Coast, Mali, Mauritania, Mauritius, Morocco, Niger, Senegal, Togo, and Tunisia: All disputes arising out of this Agreement shall be finally settled by the ICC International Court of Arbitration, in Paris (Arbitration Body), under its arbitration rules (the Rules), in Paris, France, with French as the official language, by three impartial arbitrators appointed in accordance with the Rules. Each party will nominate one arbitrator, who will jointly appoint an independent chairman within 30 days or else the chairman will be appointed by the Arbitration Body under the Rules. The arbitrators will have no authority to award injunctive relief or damages excluded by or exceeding limits in this Agreement. Nothing in this Agreement will prevent either party from resorting to judicial proceedings for (1) interim relief to prevent material prejudice or a breach of confidentiality provisions or intellectual property rights, or (2) determining the validity or ownership of any copyright, patent or trademark owned or asserted by a party or its Enterprise company, or (3) debt collection in amounts below USD 250,000.00.
+
+In South Africa, Namibia, Lesotho, and Swaziland: All disputes arising out of this Agreement shall be finally settled by the Arbitration Foundation of Southern Africa (AFSA) (Arbitration Body), under the Rules of the Arbitration of the AFSA (the Rules), in Johannesburg, South Africa, with English as the official language, by three impartial arbitrators appointed in accordance with the Rules. Each party will nominate one arbitrator, who will jointly appoint an independent chairman within 30 days or else the chairman will be appointed by the Arbitration Body under the Rules. The arbitrators will have no authority to award injunctive relief or damages excluded by or exceeding limits in this Agreement. Nothing in this Agreement will prevent either party from resorting to judicial proceedings for (1) interim relief to prevent material prejudice or a breach of confidentiality provisions or intellectual property rights, or (2) determining the validity or ownership of any copyright, patent or trademark owned or asserted by a party or its Enterprise company, or (3) debt collection in amounts below USD 250,000.00.
+
+In Andorra, Austria, Cyprus, France, Germany, Greece, Israel, Italy, Portugal, Spain, Switzerland, and Turkey: All disputes will be brought before and subject to the exclusive jurisdiction of the following court of competent jurisdiction:
+
+In Andorra: the Commercial Court of Paris.
+
+In Austria: the court of Vienna, Austria (Inner City).
+
+In Cyprus: the competent court of Nicosia.
+
+In France: Commercial Court of Paris.
+
+In Germany: the courts of Stuttgart.
+
+In Greece: the competent court of Athens.
+
+In Israel: the courts of Tel Aviv Jaffa.
+
+In Italy: the courts of Milan.
+
+In Portugal: the courts of Lisbon.
+
+In Spain: the courts of Madrid.
+
+In Switzerland: the commercial court of the canton of Zurich.
+
+In Turkey: the Istanbul Central (Caglayan) Courts and Execution Directorates of Istanbul, the Republic of Turkey.
+
+In Netherlands: The Parties waive their rights under Title 7.1 ('Koop') and clause 7:401 and 402 of the Dutch Civil Code, and their rights to invoke a full or partial dissolution ('gehele of partiele ontbinding') of this Agreement under section 6:265 of the Dutch Civil Code.
+
+Section 7. General
+
+In paragraph d, insert the following at the end of the paragraph:
+
+In Spain: IBM will comply with requests to access, update or delete contact information if submitted to the following address: IBM, c/ Santa Hortensia 26-28, 28002 Madrid, Departamento de Privacidad de Datos.
+
+In paragraph j, add to the end the paragraph:
+
+In Czech Republic: Pursuant to Section 1801 of Act No. 89/2012 Coll. (the "Civil Code"), Section 1799 and Section 1800 of the Civil Code as amended, do not apply to transactions under this Agreement. Licensee accepts the risk of a change of circumstances under Section 1765 of the Civil Code.
+
+In paragraph j:
+
+In Bulgaria, Croatia, Russia, Serbia, and Slovenia: delete the 2nd sentence that says: "Neither party will bring a legal action arising out of or related to the Agreement more than two years after the cause of action arose".
+
+In paragraph j, add to the end of the second sentence:
+
+In Lithuania: , except as provided by law
+
+In paragraph j, replace the second sentence with:
+
+In Poland: Neither party will bring a legal action arising out of or related to the Agreement more than three years after the cause of action arose, except for an action of non-payment which will be brought no more than 2 years after payment is due.
+
+In paragraph j, second sentence, replace the word "two" with:
+
+In Latvia and Ukraine: three
+
+In Slovakia: four
+
+In paragraph j, add to the end of the third sentence that says: "Neither party is responsible for failure to fulfill its non-monetary obligations due to causes beyond its control":
+
+In Russia: , including but not limited to earthquakes, floods, fires, acts of God, strikes (excluding strikes of the parties' employees), acts of war, military actions, embargoes, blockades, international or governmental sanctions, and acts of authorities of the applicable jurisdiction.
+
+In paragraph j, third sentence, modify the sentence: "Neither party is responsible for failure to fulfill its non-monetary obligations due to causes beyond its control" as follows:
+
+In Ukraine: Neither party is responsible for failure to fulfill its non-monetary obligations due to causes or regulatory changes beyond its control, including but not limited to import, export and economic sanctions requirements of the United States.
+
+Add the following at the end of the section as new paragraph l:
+
+In Hungary: By entering into this Agreement, Licensee confirms that Licensee was sufficiently informed of all the provisions of this Agreement and had the opportunity to negotiate those terms. The following provisions may significantly deviate from the provisions generally applied by Hungarian law and both parties accept those provisions by signing the Agreement: Program License; Warranties; Charges, Taxes, Payment, and Verification; Liability; Termination; Governing Laws and Geographic Scope; and General.
+
+In Czech Republic: Licensee expressly accepts the terms of this agreement which include the following important commercial terms: i) limitation and disclaimer of liability for defects (Warranties); ii) limitation of Licensee's entitlement to damages (Liability); iii) binding nature of export and import regulations (Governing Laws and Geographic Scope); iv) shorter limitation periods (General); v) exclusion of applicability of provisions on adhesion contracts (General); and vi) acceptance of the risk of a change of circumstances (General).
+
+In Romania: The Licensee expressly accepts, the following standard clauses that may be deemed 'unusual clauses' as per the provisions of article 1203 Romanian Civil Code: clauses 2, 4, 5, 8j. The Licensee hereby acknowledges that it was sufficiently informed of all the provisions of this Agreement, including the clauses mentioned above, it properly analyzed and understood such provisions and had the opportunity to negotiate the terms of each clause.
+
+i125-5543-06 (10-2021)

--- a/charts/ibm-watson-stt-embed-runtime/templates/NOTES.txt
+++ b/charts/ibm-watson-stt-embed-runtime/templates/NOTES.txt
@@ -1,0 +1,26 @@
+Thank you for installing {{ .Chart.Name }}.
+
+Your release is named {{ .Release.Name }}.
+
+To learn more about the release, try:
+
+  $ helm status {{ .Release.Name }}
+  $ helm get all {{ .Release.Name }}
+
+Example Usage:
+
+In one terminal, create a port-forward through the service:
+
+  $ kubectl port-forward svc/{{ include "ibm-watson-stt-embed-runtime.fullname" . }} 1443:443
+
+In another terminal, download an example audio file as example.flac:
+
+  $ curl --url https://github.com/watson-developer-cloud/doc-tutorial-downloads/raw/master/speech-to-text/0001.flac \
+      -sLo example.flac
+
+Send a /recognize request using the downloaded file:
+
+  $ curl --url "https://localhost:1443/speech-to-text/api/v1/recognize?model=en-US_Multimedia" \
+      --insecure \
+      --header "Content-Type: audio/flac" \
+      --data-binary @example.flac

--- a/charts/ibm-watson-stt-embed-runtime/templates/_helpers.yaml
+++ b/charts/ibm-watson-stt-embed-runtime/templates/_helpers.yaml
@@ -1,0 +1,11 @@
+{{- define "ibm-watson-stt-embed-runtime.fullname" -}}
+  {{- include "ibm-embed-helpers.fullname" . -}}
+{{- end }}
+
+{{- define "ibm-watson-stt-embed-runtime.labels" -}}
+  {{- include "ibm-embed-helpers.labels" (list . "runtime") -}}
+{{- end }}
+
+{{- define "ibm-watson-stt-embed-runtime.selectorLabels" -}}
+  {{- include "ibm-embed-helpers.selectorLabels" (list . "runtime") -}}
+{{- end }}

--- a/charts/ibm-watson-stt-embed-runtime/templates/configmap.yaml
+++ b/charts/ibm-watson-stt-embed-runtime/templates/configmap.yaml
@@ -1,0 +1,133 @@
+{{- $modelList := (list) -}}
+{{- range $model := .Values.models -}}
+  {{- if .enabled -}}
+    {{- $modelList = append $modelList $model.catalogName -}}
+  {{- end -}}
+{{- end -}}
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "ibm-watson-stt-embed-runtime.fullname" . }}
+  labels:
+    {{- include "ibm-watson-stt-embed-runtime.labels" . | nindent 4 }}
+data:
+  env_config.json: |
+    {
+      "allowDashboard": false,
+      "anonymizeLogs": false,
+      "baseModelsSURL": {
+        "service": "localPath",
+        "urlSuffix": "var/catalog.json"
+      },
+      "clusterGroups": {
+        "default": {
+          "service_type": "speech-to-text",
+          "component": "runtime",
+          "dns": "{{ include "ibm-watson-stt-embed-runtime.fullname" . }}",
+          "group": "default",
+          "models":
+            {{- $modelList | mustToPrettyJson | nindent 12 }}
+        }
+      },
+      "defaultSTTModel": "{{ .Values.defaultModel}}",
+      "defaultVerbosity": "INFO",
+      "meteringEnabled": false,
+      "requireCookies": false,
+      "setCookies": false,
+      "serviceDependencies": {
+        "baseModelsStore": {
+          "type": "UrlService",
+          "healthCheckSuffix": "/",
+          "baseUrl": "http://127.0.0.1:3333/"
+        }
+      }
+    }
+
+  sessionPools.yaml: |
+    defaultPolicy: DefaultPolicy
+    sessionPoolPolicies:
+      PreWarmingPolicy:
+{{- range $modelName := $modelList -}}
+  {{- printf "- name: %s" $modelName | nindent 8 -}}
+{{- end }}
+
+  sessionPools.py: |
+    class PreWarmingPolicy:
+        sessionPool = {
+            'minWarmSessions': 1,
+            'maxUseCount': 1000
+        }
+
+    class NoPreWarmingPolicy:
+        sessionPool = {
+            'maxUseCount': 1000
+        }
+
+    class DefaultPolicy:
+        sessionPool = {}
+
+
+  resourceRequirements.py: |
+    class RapidResourceRequirement:
+        resourceRequirement = {
+            'marginalMem': 0.9 * 2 ** 30, # 900MB
+            'marginalCpu': 60
+        }
+
+    class RnntResourceRequirement:
+        resourceRequirement = {
+            'marginalMem': 0.06 * 2 ** 30,  # 60MB
+            'marginalCpu': 12.5
+        }
+
+  haproxy.cfg: |
+    global
+      ssl-default-bind-options no-sslv3
+      ssl-default-bind-ciphers ECDH+AESGCM:DH+AESGCM:ECDH+AES256:DH+AES256:ECDH+AES128:DH+AES:RSA+AESGCM:RSA+AES:!aNULL:!MD5:!DSS
+
+      ssl-default-server-options no-sslv3
+      ssl-default-server-ciphers ECDH+AESGCM:DH+AESGCM:ECDH+AES256:DH+AES256:ECDH+AES128:DH+AES:RSA+AESGCM:RSA+AES:!aNULL:!MD5:!DSS
+
+      tune.ssl.default-dh-param 2048
+      log  127.0.0.1:1514       local0  debug
+
+    defaults
+      mode http
+      log global
+      option httplog
+      option dontlognull
+
+      retries 0
+      timeout connect 5000
+      timeout client 100000
+      timeout server 100000
+      option http-server-close
+      option http-no-delay
+
+      # JSON error responses
+      errorfile 400 /etc/haproxy/errors/400_json.http
+      errorfile 403 /etc/haproxy/errors/403_json.http
+      errorfile 408 /etc/haproxy/errors/408_json.http
+      errorfile 500 /etc/haproxy/errors/500_json.http
+      errorfile 502 /etc/haproxy/errors/502_json.http
+      errorfile 503 /etc/haproxy/errors/503_json.http
+      errorfile 504 /etc/haproxy/errors/504_json.http
+
+      stats enable
+      stats uri /stats
+
+    frontend the-frontend
+      bind *:1443 ssl crt /tmp/haproxy.tls
+
+      http-request add-header Via %[req.ver]\ %fi
+      http-request add-header X-Forwarded-Proto http if { hdr_cnt(X-Forwarded-Proto) eq 0 }
+      capture request header X-Global-Transaction-Id len 32
+      default_backend the-backend
+
+    backend the-backend
+      server runtime 127.0.0.1:1080 check
+
+
+  prepareModels.sh: |-
+    {{ tpl (.Files.Get "files/prepareModels.sh") . | nindent 4 }}

--- a/charts/ibm-watson-stt-embed-runtime/templates/deployment.yaml
+++ b/charts/ibm-watson-stt-embed-runtime/templates/deployment.yaml
@@ -1,0 +1,216 @@
+{{- if not (eq .Values.license true) }}
+{{- fail "Product licenses must be read and accepted. Then set `license` to true" }}
+{{- end }}
+
+{{- /* Construct the list of model images to use in initContainers */}}
+{{- $modelsList := (include "ibm-embed-helpers.enabledModelImageConfigs" .) | fromYamlArray }}
+
+{{- /* Always include the model catalog upload */}}
+{{- $modelsList = concat (list .Values.images.catalog) $modelsList }}
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "ibm-watson-stt-embed-runtime.fullname" . }}
+  labels:
+    {{- include "ibm-watson-stt-embed-runtime.labels" . | nindent 4 }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "ibm-watson-stt-embed-runtime.selectorLabels" . | nindent 6 }}
+  progressDeadlineSeconds: 1800
+  template:
+    metadata:
+      labels:
+        {{- include "ibm-watson-stt-embed-runtime.labels" . | nindent 8 }}
+    spec:
+      imagePullSecrets:
+        {{- .Values.imagePullSecrets | toYaml | nindent 8 }}
+
+      {{- include "ibm-embed-helpers.podSecurityContext" . | nindent 6 -}}
+
+      initContainers:
+      {{- range $index, $model := $modelsList }}
+      - name: {{ $model.repository }}
+        image: {{ include "ibm-embed-helpers.imageReference" (list $ $model) }}
+        {{- include "ibm-embed-helpers.containerSecurityContext" . | nindent 8 -}}
+        env:
+        - name: ACCEPT_LICENSE
+          value: {{ $.Values.license | quote }}
+        resources:
+          {{- $.Values.resources.runtime | toYaml | nindent 10 }}
+
+        {{- if contains "generic-models" $model.repository }}
+        # use args to not override license entrypoint
+        args: ["cp", "catalog.json", "/opt/ibm/chuck.x86_64/var"]
+        volumeMounts:
+        - name: chuck-var
+          mountPath: /opt/ibm/chuck.x86_64/var
+        {{- else }}
+        # use args to not override license entrypoint
+        args:
+        - sh
+        - -c
+        - cp model/* /models/pool2
+        volumeMounts:
+        - name: chuck-models
+          mountPath: /models/pool2
+        {{- end }}
+      {{- end }}
+
+      - name: prepare-models
+        image: {{ include "ibm-embed-helpers.imageReference" (list . .Values.images.runtime) }}
+        {{- include "ibm-embed-helpers.containerSecurityContext" . | nindent 8 -}}
+        # use args to not override license entrypoint
+        args: ["bash", "/prepareModels.sh"]
+        env:
+        - name: ACCEPT_LICENSE
+          value: {{ $.Values.license | quote }}
+        resources:
+          {{- .Values.resources.runtime | toYaml | nindent 10 }}
+        volumeMounts:
+        - name: chuck-var
+          mountPath: /opt/ibm/chuck.x86_64/var
+        - name: chuck-logs
+          mountPath: /opt/ibm/chuck.x86_64/logs
+        - name: chuck-models
+          mountPath: /models/pool2
+        - name: config
+          subPath: prepareModels.sh
+          mountPath: "/prepareModels.sh"
+        - name: config
+          mountPath: /opt/ibm/chuck.x86_64/var/env_config.json
+          subPath: env_config.json
+        - name: tmp
+          mountPath: /tmp
+
+      containers:
+      - name: runtime
+        image: {{ include "ibm-embed-helpers.imageReference" (list . .Values.images.runtime) }}
+        {{- include "ibm-embed-helpers.containerSecurityContext" . | nindent 8 -}}
+        resources:
+          {{- .Values.resources.runtime | toYaml | nindent 10 }}
+        env:
+        - name: ACCEPT_LICENSE
+          value: {{ $.Values.license | quote }}
+        - name: KUBERNETES_RESOURCE_CPUS
+          valueFrom:
+            resourceFieldRef:
+              containerName: runtime
+              resource: requests.cpu
+        - name: KUBERNETES_RESOURCE_MEM
+          valueFrom:
+            resourceFieldRef:
+              containerName: runtime
+              resource: requests.memory
+        ports:
+        - containerPort: 1080
+        startupProbe:
+          tcpSocket:
+            port: 1080
+          periodSeconds: 30
+          failureThreshold: 12
+        readinessProbe:
+          httpGet:
+             port: 1080
+             path: /v1/miniHealthCheck
+          periodSeconds: 10
+          timeoutSeconds: 1
+        livenessProbe:
+          tcpSocket:
+            port: 1080
+          periodSeconds: 30
+        volumeMounts:
+        - name: chuck-var
+          mountPath: /opt/ibm/chuck.x86_64/var
+        - name: chuck-logs
+          mountPath: /opt/ibm/chuck.x86_64/logs
+        - name: config
+          subPath: env_config.json
+          mountPath: /opt/ibm/chuck.x86_64/var/env_config.json
+        - name: config
+          subPath: sessionPools.yaml
+          mountPath: /opt/ibm/chuck.x86_64/var/sessionPools.yaml
+        - name: config
+          subPath: sessionPools.py
+          mountPath: /opt/ibm/chuck.x86_64/var/sessionPools.py
+        - name: config
+          subPath: resourceRequirements.py
+          mountPath: /opt/ibm/chuck.x86_64/var/resourceRequirements.py
+        # ephemeral volume for scratch space
+        - name: tmp
+          mountPath: /tmp
+        lifecycle:
+          preStop:
+            exec:
+              command:
+              - /bin/sleep
+              - "15"
+
+      - name: haproxy
+        image: {{ include "ibm-embed-helpers.imageReference" (list . .Values.images.haproxy) }}
+        {{- include "ibm-embed-helpers.containerSecurityContext" . | nindent 8 -}}
+        # use args to not override license entrypoint
+        args:
+          - sh
+          - -c
+          # HAProxy needs a single file with the key and cert
+          #   write combined file to a read-write mount
+          - cat /etc/ssl/private/server/tls.crt /etc/ssl/private/server/tls.key > /tmp/haproxy.tls;
+            exec /runHaproxy.sh;
+        resources:
+          {{- .Values.resources.haproxy | toYaml | nindent 10 }}
+        env:
+        - name: ACCEPT_LICENSE
+          value: {{ .Values.license | quote }}
+        ports:
+        - containerPort: 1443
+        readinessProbe:
+          httpGet:
+            path: /v1
+            port: 1443
+            scheme: HTTPS
+          initialDelaySeconds: 10
+          periodSeconds: 10
+          timeoutSeconds: 1
+        livenessProbe:
+          tcpSocket:
+            port: 1443
+          initialDelaySeconds: 15
+          periodSeconds: 30
+        volumeMounts:
+        - mountPath: /etc/ssl/private/server
+          name: server-tls
+        - mountPath: /etc/haproxy/haproxy.cfg
+          name: config
+          subPath: haproxy.cfg
+        - name: tmp
+          mountPath: /tmp
+
+      volumes:
+        - name: chuck-var
+          emptyDir: {}
+        - name: chuck-models
+          emptyDir: {}
+        - name: chuck-cache
+          emptyDir: {}
+        - name: chuck-logs
+          emptyDir: {}
+        - name: config
+          configMap:
+            name: {{ include "ibm-watson-stt-embed-runtime.fullname" . }}
+        - name: tmp
+          emptyDir: {}
+        - name: server-tls
+          secret:
+            secretName: {{ include "ibm-watson-stt-embed-runtime.fullname" . }}-tls-server
+
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: "kubernetes.io/arch"
+                operator: In
+                values:
+                  - "amd64"

--- a/charts/ibm-watson-stt-embed-runtime/templates/service.yaml
+++ b/charts/ibm-watson-stt-embed-runtime/templates/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "ibm-watson-stt-embed-runtime.fullname" . }}
+  labels:
+    {{- include "ibm-watson-stt-embed-runtime.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.serviceType }}
+  selector:
+    {{- include "ibm-watson-stt-embed-runtime.selectorLabels" . | nindent 4 }}
+  ports:
+    - name: https
+      protocol: TCP
+      port: 443
+      targetPort: 1443

--- a/charts/ibm-watson-stt-embed-runtime/templates/tls.yaml
+++ b/charts/ibm-watson-stt-embed-runtime/templates/tls.yaml
@@ -1,0 +1,24 @@
+{{/*
+Generate a Certificate Authority Cert
+*/}}
+{{- $rootca := genCA "ibm-watson-stt-embed-runtime-ca" 3650 -}}
+
+{{/*
+Server Certificate
+*/}}
+{{- $altNames := list -}}
+{{- $runtimeService := include "ibm-watson-stt-embed-runtime.fullname" . -}}
+{{- $altNames := append $altNames "localhost" -}}
+{{- $altNames := append $altNames (printf "%s" $runtimeService) -}}
+{{- $altNames := append $altNames (printf "%s.%s" $runtimeService .Release.Namespace) -}}
+{{- $altNames := append $altNames (printf "%s.%s.svc" $runtimeService .Release.Namespace) -}}
+{{- $serverCert := include "ibm-embed-helpers.genCert" (list $rootca $altNames) | fromJson -}}
+
+apiVersion: v1
+kind: Secret
+type: kubernetes.io/tls
+metadata:
+  name: {{ include "ibm-watson-stt-embed-runtime.fullname" . }}-tls-server
+  labels:
+    {{- include "ibm-watson-stt-embed-runtime.labels" . | nindent 4 }}
+stringData: {{- include "ibm-embed-helpers.certStringdata" (list $rootca $serverCert) -}}

--- a/charts/ibm-watson-stt-embed-runtime/values.yaml
+++ b/charts/ibm-watson-stt-embed-runtime/values.yaml
@@ -1,0 +1,176 @@
+# By setting license to true you indicate that you have read and agree to the
+# license agreements:
+# https://www14.software.ibm.com/cgi-bin/weblap/lap.pl?li_formnum=L-DAJI-CHRHDK
+license: false
+
+containerRegistry: "cp.icr.io/cp/ai"
+serviceType: ClusterIP
+imagePullSecrets:
+  - name: ibm-entitlement-key
+
+nameOverride: ""
+fullnameOverride: ""
+
+images:
+  runtime:
+    repository: watson-stt-runtime
+    digest: sha256:00a8bb35458333431b2740f81c5581eae76b693911c7eb9b5b6b541fac923a09
+    tag: 1.0.0
+  haproxy:
+    repository: watson-stt-haproxy
+    digest: sha256:f9545e7059d9f86ad9539dee2f83f79e63d8578816120540f3f9f14f674e545e
+    tag: 1.0.0
+  catalog:
+    repository: watson-stt-generic-models
+    digest: sha256:4bfe7e0eba7c56458032d0a580cfa43f5cb6fd4a9db8a4407c3fa250b547b541
+    tag: 1.0.0
+
+# Configures the resources
+resources:
+  runtime:
+    requests:
+      cpu: 1
+      memory: 4Gi
+      ephemeral-storage: 4Gi
+    limits:
+      cpu: 4
+      memory: 4Gi
+      ephemeral-storage: 4Gi
+  haproxy:
+    requests:
+      cpu: 0.2
+      memory: 1Gi
+      ephemeral-storage: 64Mi
+    limits:
+      cpu: 1
+      memory: 1Gi
+      ephemeral-storage: 64Mi
+
+defaultModel: en-US_Multimedia
+models:
+  arMSTelephony:
+    catalogName: ar-MS_Telephony
+    repository: watson-stt-ar-ms-telephony
+    digest: sha256:b2d58b44017b5ff088f7e678a368b3fd0d72d7baefb302bbaf04cfd48b6bae0f
+    tag: 1.0.0
+    enabled: false
+  csCZTelephony:
+    catalogName: cs-CZ_Telephony
+    repository: watson-stt-cs-cz-telephony
+    digest: sha256:c2b8b3fbb14980a72bb38d2de13c459dcfc6b42708d63abdc761d484590a7624
+    tag: 1.0.0
+    enabled: false
+  deDEMultimedia:
+    catalogName: de-DE_Multimedia
+    repository: watson-stt-de-de-multimedia
+    digest: sha256:914284dacb43b4b4b13c0068dddf4fe2c253d5efee6ffddd9712b2fad440e526
+    tag: 1.0.0
+    enabled: false
+  deDETelephony:
+    catalogName: de-DE_Telephony
+    repository: watson-stt-de-de-telephony
+    digest: sha256:655054d10cb1e2c9f1822fb21e251d10a0432f360780bda8bafd6a77d7a2c4b7
+    tag: 1.0.0
+    enabled: false
+  enINTelephony:
+    catalogName: en-IN_Telephony
+    repository: watson-stt-en-in-telephony
+    digest: sha256:76d2940804dd1ae2435e305a052c6178a6d4036cb54e2b42cadd0f7f66e854c4
+    tag: 1.0.0
+    enabled: false
+  enUSMultimedia:
+    catalogName: en-US_Multimedia
+    repository: watson-stt-en-us-multimedia
+    digest: sha256:ad0b85f018b6ccd2ebe07f6b2979840c94a3e4076368d59fd6ebcb57b2df842b
+    tag: 1.0.0
+    enabled: true
+  enUSTelephony:
+    catalogName: en-US_Telephony
+    repository: watson-stt-en-us-telephony
+    digest: sha256:fb2e5cf4b9ab76af0ee7d3a774b518fbab3eaac82e1564fe7910bd90fa8a70a7
+    tag: 1.0.0
+    enabled: true
+  enWWMedicalTelephony:
+    catalogName: en-WW_Medical_Telephony
+    repository: watson-stt-en-ww-medical-telephony
+    digest: sha256:d231b5058eea28cdeff005bc48365f600d9343df580979b781d53bf742d7ff15
+    tag: 1.0.0
+    enabled: false
+  esESMultimedia:
+    catalogName: es-ES_Multimedia
+    repository: watson-stt-es-es-multimedia
+    digest: sha256:082b0ca2f90c6519ee7303be56d68bc95b3655cb14c41bd8ad09a4960bff5015
+    tag: 1.0.0
+    enabled: false
+  esESTelephony:
+    catalogName: es-ES_Telephony
+    repository: watson-stt-es-es-telephony
+    digest: sha256:d3fb27ae270d35f5948e7906680df52b329e473738e3cb1e49edc663384d1a8c
+    tag: 1.0.0
+    enabled: false
+  esLATelephony:
+    catalogName: es-LA_Telephony
+    repository: watson-stt-es-la-telephony
+    digest: sha256:e5521acc6af46f6a2f8ef1a5f388872c75003be0063ff0db6868866ee7f1dd70
+    tag: 1.0.0
+    enabled: false
+  frFRMultimedia:
+    catalogName: fr-FR_Multimedia
+    repository: watson-stt-fr-fr-multimedia
+    digest: sha256:9818391a631df91eda10a26120efa0c699e1c4511e2c17b511468d80be20e8f3
+    tag: 1.0.0
+    enabled: false
+  frFRTelephony:
+    catalogName: fr-FR_Telephony
+    repository: watson-stt-fr-fr-telephony
+    digest: sha256:0c0694d7835dcd47e3c16641d64d998613396c6acddb62b9e0a151719e970785
+    tag: 1.0.0
+    enabled: false
+  hiINTelephony:
+    catalogName: hi-IN_Telephony
+    repository: watson-stt-hi-in-telephony
+    digest: sha256:c23a402e282f48efc993f95e32057d6f1c16d6e5042671f87864e7dd2aa2ac2c
+    tag: 1.0.0
+    enabled: false
+  itITTelephony:
+    catalogName: it-IT_Telephony
+    repository: watson-stt-it-it-telephony
+    digest: sha256:8ca6e2209ceff203bc63f33e7871fab0712f46e49e0cc37e92d8be00a9814f38
+    tag: 1.0.0
+    enabled: false
+  jaJPMultimedia:
+    catalogName: ja-JP_Multimedia
+    repository: watson-stt-ja-jp-multimedia
+    digest: sha256:6df67bdf156f4dcfec4e7c92e022e20e64e2c55010b9e69c92e4de9518c9ba79
+    tag: 1.0.0
+    enabled: false
+  koKRMultimedia:
+    catalogName: ko-KR_Multimedia
+    repository: watson-stt-ko-kr-multimedia
+    digest: sha256:46158c3a79b6d6f90cd814a9c70431d0d31143fa6904661152d220608f673a36
+    tag: 1.0.0
+    enabled: false
+  koKRTelephony:
+    catalogName: ko-KR_Telephony
+    repository: watson-stt-ko-kr-telephony
+    digest: sha256:482258035688a07aaf8b7ee5e0e31ffde421dcd710d6df84c60bbb5417c29fe4
+    tag: 1.0.0
+    enabled: false
+  nlBETelephony:
+    catalogName: nl-BE_Telephony
+    repository: watson-stt-nl-be-telephony
+    digest: sha256:c116c00eb180ff0cc7935363b9f08775a3265e9ac7486bad9d88c6a72ad94533
+    tag: 1.0.0
+    enabled: false
+  nlNLTelephony:
+    catalogName: nl-NL_Telephony
+    repository: watson-stt-nl-nl-telephony
+    digest: sha256:794a7ba8f212935461fa5936fbce49e17df54d2f2c9f49529e883501bf8ef369
+    tag: 1.0.0
+    enabled: false
+  zhCNTelephony:
+    catalogName: zh-CN_Telephony
+    repository: watson-stt-zh-cn-telephony
+    digest: sha256:52c41fe7433126153027e1e69163848f74249da580c374f2413c615d8737d1dc
+    tag: 1.0.0
+    enabled: false

--- a/charts/ibm-watson-tts-embed-runtime/.helmignore
+++ b/charts/ibm-watson-tts-embed-runtime/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/ibm-watson-tts-embed-runtime/Chart.yaml
+++ b/charts/ibm-watson-tts-embed-runtime/Chart.yaml
@@ -1,0 +1,19 @@
+apiVersion: v2
+name: ibm-watson-tts-embed-runtime
+description: |
+  Demonstrates how to configure a deployment of the Watson Text to Speech
+  Library for Embed Runtime server.
+
+  License
+
+  By installing the containers you accept the license terms at:
+  https://www14.software.ibm.com/cgi-bin/weblap/lap.pl?li_formnum=L-DAJI-CJULPU
+home: https://www.ibm.com/docs/watson-libraries?topic=watson-text-speech-library-embed-home
+
+type: application
+version: "0.1.0"
+appVersion: "1.0.0"
+
+dependencies:
+  - name: ibm-embed-helpers
+    version: "0.0.0"

--- a/charts/ibm-watson-tts-embed-runtime/LICENSE
+++ b/charts/ibm-watson-tts-embed-runtime/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/charts/ibm-watson-tts-embed-runtime/README.md
+++ b/charts/ibm-watson-tts-embed-runtime/README.md
@@ -1,0 +1,115 @@
+# IBM Watson Text to Speech Library for Embed
+
+The Watson Text to Speech (TTS) Library for Embed synthesizes natural-sounding speech from written text. The service streams the results back to the client with minimal delay.
+
+## Introduction
+
+This chart provides a functioning exemplar install of the IBM Watson Text to Speech Embed runtime on Kubernetes.
+
+This chart should be treated as beta when considering compatibility and future changes. It is recommended to either copy and modify the chart or the manifests it renders.
+
+Find out more about IBM Text to Speech Library for Embed by reading the [product documentation](https://www.ibm.com/docs/watson-libraries?topic=watson-text-speech-library-embed-home).
+
+## Chart Details
+
+This chart installs the following:
+
+- TTS runtime Deployment
+  - HAProxy container used for TLS termination
+  - The set of enabled models are downloaded and configured via `initContainers`
+- Service to expose the Deployment
+- ConfigMap with configuration files that are mounted into the containers
+- TLS secrets with a self-signed CA and the server certificate
+
+## Prerequisites
+
+- [Helm 3](https://helm.sh/docs/intro/install/)
+- [Get access to the images with an IBM entitlement key](https://www.ibm.com/docs/watson-libraries?topic=i-accessing-files-1)
+
+### License acceptance
+
+To run the Text to Speech images (runtime and models) the product licenses must be reviewed and accepted by setting the value `license: true`.
+
+The product licenses are contained in the `/license` directory or can be [viewed online](https://www14.software.ibm.com/cgi-bin/weblap/lap.pl?li_formnum=L-DAJI-CJULPU).
+
+### Red Hat OpenShift SecurityContextConstraints
+
+Security context constraints (SCCs) can be set on individual containers to control permissions. These permissions include actions a container can perform and what resources it can access. RedHat Openshift has a set of default SCCs to define a set of conditions that a container must run with to be accepted into the system.
+
+These values are preset within the chart:
+
+```yaml
+securityContext:
+  allowPrivilegeEscalation: false
+  capabilities:
+    drop:
+    - ALL
+  privileged: false
+  readOnlyRootFilesystem: true
+  runAsNonRoot: true
+```
+
+## Installing the Chart
+
+The containers deployed in this chart come from the IBM entitled registry. You must create a Secret with credentials to pull from the IBM entitled registry. `ibm-entitlement-key` is the default name, but this can be changed by updating the `imagePullSecrets` value.
+
+An example command to create the pull secret:
+
+```sh
+  $ kubectl create secret docker-registry ibm-entitlement-key \
+  --docker-server=cp.icr.io \
+  --docker-username=<your-name> \
+  --docker-password=<your-password> \
+  --docker-email=<your-email>
+```
+
+Before installing the chart, the license terms must be reviewed. Set `license=true` when installing to accept the license:
+
+```sh
+$ helm install --set license=true --set nameOverride=tts my-release ./ibm-watson-tts-embed-runtime
+```
+
+By default, the models that are enabled are `en-US_MichaelV3Voice` and `en-US_AllisonV3Voice` with `defaultModel` set to `en-US_AllisonV3Voice`.
+
+To configure the install further, such as enabling additional models, it is recommended to use a [values configuration file](#configuration).
+
+## Verifying the Chart
+
+See the instruction (from NOTES.txt within chart) after the helm installation completes for chart verification. The instruction can also be viewed by running the command.
+
+```sh
+$ helm status my-release
+```
+
+## Uninstalling the Chart
+
+To uninstall and delete the Text to Speech deployment, run the following command:
+
+```sh
+$ helm delete my-release
+```
+
+## Configuration
+
+Helm charts have configurable values that can be set at install time. Refer to the base [values.yaml](values.yaml) for documentation and defaults for the values. Values can be changed using `--set` or using YAML files specified with `-f/--values`
+
+An example YAML values file can be found below:
+
+```yaml
+# Required to indicate acceptance of the container product license
+license: true
+
+# Use a simpler name for resources created by the Helm chart
+nameOverride: "tts"
+
+# Change the default model when none is specified in the request
+defaultModel: de-DE_BrigitV3Voice
+# Enable additional models from the default ones
+models:
+  deDEBirgitV3Voice:
+    enabled: true
+  esESLauraV3Voice:
+    enabled: true
+```
+
+See the [product's configuration documentation](https://www.ibm.com/docs/watson-libraries?topic=r-configuration-options-1) for details on how the containers are configured.

--- a/charts/ibm-watson-tts-embed-runtime/charts/ibm-embed-helpers
+++ b/charts/ibm-watson-tts-embed-runtime/charts/ibm-embed-helpers
@@ -1,0 +1,1 @@
+../../ibm-embed-helpers/

--- a/charts/ibm-watson-tts-embed-runtime/files/prepareModels.sh
+++ b/charts/ibm-watson-tts-embed-runtime/files/prepareModels.sh
@@ -1,0 +1,40 @@
+#! /usr/bin/env bash
+# The purpose of this script is to process the archives contained in the model
+# container images to populate the model "cache" that the runtime uses when it
+# loads models. If the cache is populated, the runtime loads from it instead of
+# depending on model store service.
+#
+# We use the runtime code itself to populate the cache by booting the runtime
+# with a simple Python file server serving the archives. The runtime imports the
+# models and populates the cache. After the cache is populated, the runtime can
+# boot without the file server.
+set -u
+
+cleanup() {
+  local pids=$(jobs -pr)
+  if [ -n "$pids" ]; then
+    kill $pids
+  fi
+}
+trap "cleanup" SIGINT SIGQUIT SIGTERM EXIT
+
+python -m http.server --bind 127.0.0.1 --directory /models 3333 &
+
+./runChuck.sh &
+
+# wait for the server to become ready, which happens after it downloads the models
+max_tries=10
+tries=0
+while [[ tries -lt max_tries ]]; do
+  curl -sk -o /dev/null "localhost:1080/v1/miniHealthCheck"
+  if [[ $? -eq 0 ]]; then
+    echo "Model initialization complete"
+    exit 0
+  fi
+
+  sleep 1
+  ((tries+=1))
+done
+
+echo "Server failed to initialize models in time."
+exit 1

--- a/charts/ibm-watson-tts-embed-runtime/licenses/LICENSE
+++ b/charts/ibm-watson-tts-embed-runtime/licenses/LICENSE
@@ -1,0 +1,1030 @@
+-----
+
+IMPORTANT: READ CAREFULLY
+
+Two license agreements are presented below.
+
+1. IBM International License Agreement for Evaluation of Programs
+2. IBM International Program License Agreement
+
+If Licensee is obtaining the Program for purposes of productive use (other than evaluation, testing, trial "try or buy," or demonstration): By setting the environment variable ACCEPT_LICENSE=true, Licensee accepts the IBM International Program License Agreement, without modification.
+
+If Licensee is obtaining the Program for the purpose of evaluation, testing, trial "try or buy," or demonstration (collectively, an "Evaluation"): By setting the environment variable ACCEPT_LICENSE=true, Licensee accepts both (i) the IBM International License Agreement for Evaluation of Programs (the "Evaluation License"), without modification; and (ii) the IBM International Program License Agreement (the "IPLA"), without modification.
+
+The Evaluation License will apply during the term of Licensee's Evaluation.
+
+The IPLA will automatically apply if Licensee elects to retain the Program after the Evaluation (or obtain additional copies of the Program for use after the Evaluation) by entering into a procurement agreement (e.g., the IBM International Passport Advantage or the IBM Passport Advantage Express agreements).
+
+The Evaluation License and the IPLA are not in effect concurrently; neither modifies the other; and each is independent of the other.
+
+The complete text of each of these two license agreements follow.
+
+The translated license terms can be viewed here: https://www14.software.ibm.com/cgi-bin/weblap/lap.pl?li_formnum=L-DAJI-CJULPU
+
+-----
+
+LICENSE INFORMATION
+
+The Programs listed below are licensed under the following License Information terms and conditions in addition to the Program license terms previously agreed to by Client and IBM. If Client does not have previously agreed to license terms in effect for the Program, the International Program License Agreement (i125-3301-15) applies.
+
+Program Name (Program Number):
+IBM Watson Speech to Text Library for Embed 1.0.0 (5900-AT9)
+
+The following standard terms apply to Licensee's use of the Program.
+
+Modifiable Third Party Code
+
+To the extent, if any, in the NOTICES file IBM identifies third party code as "Modifiable Third Party Code," IBM authorizes Licensee to 1) modify the Modifiable Third Party Code and 2) reverse engineer the Program modules that directly interface with the Modifiable Third Party Code provided that it is only for the purpose of debugging Licensee's modifications to such third party code. IBM's service and support obligations, if any, apply only to the unmodified Program.
+
+Separately Licensed Code
+
+Each of the components listed in the NON_IBM_LICENSE file is considered "Separately Licensed Code" licensed to Licensee under the terms of the applicable third party license agreement(s) set forth in the NON_IBM_LICENSE file(s) that accompanies the Program, and not this Agreement. Future Program updates or fixes may contain additional Separately Licensed Code. Such additional Separately Licensed Code and related licenses are listed in the applicable NON_IBM_LICENSE file that accompanies the Program update or fix.
+
+Note: Notwithstanding any of the terms in the third party license agreement, the Agreement, or any other agreement Licensee may have with IBM, with respect to the Separately Licensed Code:
+(a) IBM provides it to Licensee WITHOUT WARRANTIES OF ANY KIND AND DISCLAIMS ANY AND ALL EXPRESS AND IMPLIED WARRANTIES AND CONDITIONS INCLUDING, BUT NOT LIMITED TO, THE WARRANTY OF TITLE, NON-INFRINGEMENT OR NON-INTERFERENCE, AND THE IMPLIED WARRANTIES AND CONDITIONS OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE;
+(b) IBM is not liable for any direct, indirect, incidental, special, exemplary, punitive or consequential damages including, but not limited to, lost data, lost savings, and lost profits.
+
+Benchmarking
+
+Licensee may disclose the results of any benchmark test of the Program or its subcomponents to any third party provided that Licensee (A) publicly discloses the complete methodology used in the benchmark test (for example, hardware and software setup, installation procedure and configuration files), and (B) performs testing running the Program in its Specified Operating Environment using the latest applicable updates, patches, fixes, performance tuning, and best practices guidance available for the Program,. If Licensee publishes the results of any benchmark tests for the Program, then IBM (including third parties providing IBM products "Third Parties") will have the right to publish the results of benchmark tests with respect to Licensee's products provided IBM or Third Parties complies with the requirements of (A), and (B) above in its testing of Licensee's products.
+
+Notwithstanding the foregoing, under no circumstances may Licensee publish the results of benchmark tests run on Oracle Outside In Technology without prior written permission.
+
+The following units of measure may apply to Licensee's use of the Program.
+
+Monthly Minute
+
+Monthly Minute is a unit of measure by which the Program can be licensed. A Minute is a unit of time equal to 60 seconds. Total number of whole or partial Minutes in any calendar month are added together and then rounded up to the nearest whole Minute. Sufficient entitlements must be obtained to cover the number of Minutes analyzed or processed by the Program in any calendar month.
+
+L/N:  L-DAJI-CHRHDK
+D/N:  L-DAJI-CHRHDK
+P/N:  L-DAJI-CHRHDK
+
+
+
+-----
+
+International Program License Agreement
+
+Part 1 - General Terms
+
+BY DOWNLOADING, INSTALLING, COPYING, ACCESSING, CLICKING ON AN "ACCEPT" BUTTON, OR OTHERWISE USING THE PROGRAM, LICENSEE AGREES TO THE TERMS OF THIS AGREEMENT. IF YOU ARE ACCEPTING THESE TERMS ON BEHALF OF LICENSEE, YOU REPRESENT THAT YOU HAVE FULL AUTHORITY TO BIND LICENSEE TO THESE TERMS.
+
+IF YOU DO NOT AGREE TO THESE TERMS OR DO NOT HAVE AUTHORITY: i) DO NOT DOWNLOAD, INSTALL, COPY, ACCESS, CLICK ON AN "ACCEPT" BUTTON, OR USE THE PROGRAM; AND ii) PROMPTLY RETURN THE UNUSED MEDIA, DOCUMENTATION, AND PROOF OF ENTITLEMENT TO THE PARTY FROM WHOM IT WAS OBTAINED FOR A REFUND OF THE AMOUNT PAID. IF THE PROGRAM WAS DOWNLOADED, DESTROY ALL COPIES OF THE PROGRAM.
+
+This International Program License Agreement (IPLA) and applicable Transaction Documents (together the "Agreement") are the complete agreement between Licensee and IBM regarding the use of a Program. The country required terms included in Part 2 of this IPLA replace or modify the terms of Part 1.
+
+Transaction Documents (TDs) provide a description, information, and terms regarding the Program and its authorized use. Examples of TDs for Programs include license information (LI), licensed program specifications (LPS), quote, proof of entitlement (PoE), or invoice. To the extent of any conflict a TD will prevail over the IPLA.
+
+1. Program License
+
+a. A Program is an executable IBM-branded computer program and its related material and includes whole and partial copies. Program details are described in a TD available at http://www.ibm.com/software/sla (for Passport Advantage Programs) or http://www.ibm.com/support/knowledgecenter (for other IBM Programs), in the Program's system command directory, or as otherwise specified by IBM. IBM software policies (such as backup, temporary use and IBM approved cloud environment) available at http://www.ibm.com/softwarepolicies apply to Licensee's use of Programs.
+
+b. Copies of Programs are copyrighted and licensed.
+
+c. Licensee is granted a nonexclusive license to:
+
+(1) use each copy of a Program, subject to the terms of the Agreement and up to the number of license entitlements Licensee acquires ("Authorized Use");
+
+(2) make and install copies to support such Authorized Use; and
+
+(3) make a backup copy.
+
+d. Programs may be used by Licensee, its employees and contractors. Licensee may not rent or lease a Program or provide commercial IT, hosting or timesharing services to any third party. Additional rights may be available for additional fees or under different terms.
+
+e. The license granted for a Program is subject to Licensee:
+
+(1) reproducing copyright notices and other markings on any copy;
+
+(2) ensuring anyone who uses the Program: i) does so only on Licensee's behalf within Licensee's Authorized Use; and ii) complies with this Agreement;
+
+(3) not reverse assembling, reverse compiling, translating, or reverse engineering the Program, except as expressly permitted by law without the possibility of contractual waiver; and
+
+(4) not using any of the elements of the Program or related licensed materials separately from the Program.
+
+f. If the TD for a Program ("Principal Program") states that a "Supporting Program" is included with the Principal Program, Licensee may use the Supporting Program subject to any license limitations of the Principal Program and only to support the Principal Program.
+
+g. This license applies to each copy of the Program that Licensee makes.
+
+h. An update, fix, or patch to a Program is subject to the terms governing the Program unless new terms are provided in an updated TD. Licensee accepts such new terms upon installation of the update, fix, or patch. If a Program is replaced by an update, Licensee agrees to promptly discontinue use of the replaced Program.
+
+i. If Licensee is dissatisfied with a Program for any reason, Licensee may terminate the license by returning the Program and proof of entitlement to IBM or the authorized IBM Business Partner within 30 days of the original acquisition date of such Program for a refund of the amount paid. For a downloaded Program, contact the party Licensee acquired the Program from for refund instructions.
+
+2. Warranties
+
+a. IBM warrants that a Program, when used in its specified operating environment conforms to its specifications. The warranty period for a Program is 12 months from acquisition, or the initial license term if less than 12 months, unless another warranty period is specified in the TD.
+
+b. During the warranty period Licensee will have access to IBM databases containing information on known Program defects, defect corrections, restrictions, and bypasses as described in the IBM Support Guide at http://www.ibm.com/support/pages/node/733923.
+
+c. If the Program does not function as warranted during its warranty period and the problem cannot be resolved with information available in the IBM databases, Licensee may return the Program and proof of entitlement to IBM or the IBM Business Partner for a refund of the amount Licensee paid and Licensee's license terminates.
+
+d. IBM does not warrant uninterrupted or error-free operation of an IBM Program or that IBM will correct all defects or prevent third party disruptions. These warranties are the exclusive warranties from IBM and replace all other warranties, including the implied warranties or conditions of satisfactory quality, merchantability, non-infringement, and fitness for a particular purpose. IBM warranties will not apply if there has been misuse, modification, damage not caused by IBM, or failure to comply with written instructions provided by IBM. Non-IBM Programs are provided as-is, without warranties of any kind. Third parties may provide their own warranties to Licensee.
+
+e. Additional support available during or after the warranty period may be available under separate agreement.
+
+3. Charges, Taxes, Payment, and Verification
+
+a. Licensee's right to use a Program is contingent on Licensee paying applicable charges as specified in the agreement under which Licensee acquired the license entitlements. Licensee is responsible to acquire additional license entitlements in advance of any increase of its use.
+
+b. Licensee agrees to pay all applicable charges for acquired entitlements and any charges for use in excess of authorizations. Charges are exclusive of any customs or other duty, tax, and similar levies imposed by any authority resulting from Licensee's acquisition of entitlements and will be invoiced in addition to such charges. Amounts are due upon receipt of the invoice from IBM and payable within 30 days of the invoice date to an account specified by IBM and late payment fees may apply. Licensee is responsible to properly acquire additional license entitlements in advance to increase its use. IBM does not give credits or refunds for charges already due or paid, except as specified elsewhere in this IPLA, the applicable TD, or terms of the agreement under which Licensee acquired license entitlements.
+
+c. Based on acquired entitlements, Licensee agrees to: i) pay any withholding tax directly to the appropriate government entity where required by law; ii) furnish a tax certificate evidencing such payment to IBM; iii) pay IBM only the net proceeds after tax; and iv) fully cooperate with IBM in seeking a waiver or reduction of such taxes and promptly complete and file all relevant documents.
+
+d. If Licensee imports, exports, transfers, accesses, or uses a Program across a border, Licensee agrees to be responsible for and pay authorities any custom, duty, tax, or similar levy assessed by the authorities. This excludes those taxes based on IBM's net income.
+
+3.1 Licensing Verification
+
+a. Licensee will, for all Programs at all sites and for all environments, create, retain, and each year provide to IBM upon request with 30 days' advance notice: i) a report, in a format requested by IBM using records, system tools output, and other system information; and ii) supporting documentation (collectively, "Deployment Data").
+
+b. Upon reasonable notice, IBM and its independent auditors may verify Licensee's compliance with this Agreement, at all sites and for all environments, in which Licensee uses (for any purposes) Programs. Verification will be conducted in a manner that minimizes disruption to Licensee's business and may be conducted on Licensee's premises, during normal business hours. IBM will have a written confidentiality agreement with the independent auditor. In addition to providing Deployment Data described above, Licensee agrees to provide to IBM and its auditors additional accurate information and Deployment Data upon request.
+
+c. Licensee will promptly order and pay charges at IBM's then current rates associated with: i) any deployments in excess of authorizations indicated on or by any annual report or verification; ii) applicable subscription & support services (S&S) for such excess deployments for the lesser of the duration of such excess use or two years; and iii) any additional charges and other liabilities determined as a result of such verification, including but not limited to taxes, duties, and regulatory fees.
+
+4. Liability and Intellectual Property Protection
+
+a. IBM's entire liability for all claims related to this Agreement will not exceed the amount of any actual direct damages incurred by Licensee up to the amounts paid (if recurring charges, up to 12 months' charges apply) for the entitlements to the Program that is the subject of the claim, regardless of the basis of the claim. IBM will not be liable for special, incidental, exemplary, indirect, or economic consequential damages, or for lost profits, business, value, revenue, goodwill, or anticipated savings. These limitations apply collectively to IBM, its affiliates, contractors, and suppliers.
+
+b. The following amounts are not subject to the above cap: i) third party payments related to infringement claims described in clause 4 c below; and ii) damages that cannot be limited under applicable law.
+
+c. If a third party asserts a claim against Licensee that an IBM Program infringes a patent or copyright, IBM will defend Licensee against that claim and pay amounts finally awarded by a court against Licensee or included in a settlement approved by IBM. To obtain IBM's defense against and payment of infringement claims, Licensee must promptly: i) notify IBM in writing of the claim; ii) supply information requested by IBM; and iii) allow IBM to control, and reasonably cooperate in, the defense and settlement, including mitigation efforts. IBM's defense and payment obligations for infringement claims extend to claims of infringement based on open source code that IBM selects and embeds in an IBM Program.
+
+d. IBM has no responsibility for claims based on non-IBM products, items not provided by IBM, or any violation of law or third party rights caused by Content, or any Licensee materials, designs, specifications, or use of a non-current version or release of an IBM Program when an infringement claim could have been avoided by using a current version or release. Content consists of all data, software, and information that Licensee or its authorized users provide, authorize access to, or inputs to a Program.
+
+5. Termination
+
+a. IBM may terminate Licensee's license to use a Program if Licensee fails to comply with the IPLA, TDs or acquisition agreements, such as the International Passport Advantage Agreement (IPAA). Licensee will promptly destroy all copies of the Program after license termination. Any terms that by their nature extend beyond the termination remain in effect until fulfilled and apply to successors and assignees.
+
+6. Governing Laws and Geographic Scope
+
+a. Both parties agree to the application of the laws of the country where the transaction for license entitlements is performed, without regard to conflict of law principles. The rights and obligations of each party are valid only in the country where the transaction to acquire license entitlements is performed or, if IBM agrees, the country where the Program is placed in productive use, except all licenses are valid as specifically granted.
+
+b. Each party is also responsible for complying with: i) laws and regulations applicable to its business and Content; and ii) import, export and economic sanction laws and regulations, including the defense trade control regime of the United States of America and any applicable jurisdictions, that prohibit or restrict the import, export, re-export, or transfer of products, technology, services or data, directly or indirectly, to or for certain countries, end uses or end users.
+
+c. If any provision of this Agreement for a Program, is invalid or unenforceable, the remaining provisions remain in full force and effect. Nothing in this Agreement affects statutory rights of consumers that cannot be waived or limited by contract. The United Nations Convention on Contracts for the International Sale of Goods does not apply to transactions under this Agreement.
+
+7. General
+
+a. IBM is an independent contractor, not Licensee's agent, joint venturer, partner, or fiduciary, and does not undertake to perform any of Licensee's regulatory obligations, or assume any responsibility for Licensee's business or operations. Licensee is responsible for its use of IBM Programs and Non-IBM Programs. IBM is acting as an information technology provider only. IBM's direction, suggested usage, or guidance or use of a Program does not constitute medical, clinical, legal, accounting, or other licensed professional advice. Licensee should obtain its own expert advice.
+
+b. For Programs IBM provides to Licensee in tangible form, IBM fulfills its shipping and delivery obligations upon the delivery of such Programs to the IBM-designated carrier, unless otherwise agreed to in writing by Licensee and IBM.
+
+c. Licensee may not use the Program if failure of the Program could lead to death, serious bodily injury, or property or environmental damage.
+
+d. IBM, its affiliates, and contractors of either require use of business contact information and certain account usage information. This information is not Content. Business contact information is used to communicate and manage business dealings with the Licensee. Examples of business contact information include name, business telephone, address, email, user ID, and tax registration information. Account usage information is required to enable, provide, manage, support, administer, and improve Programs. Examples of account usage information include reported errors and digital information gathered using tracking technologies, such as cookies and web beacons, during use of the Programs. The IBM Privacy Statement at http://www.ibm.com/privacy provides additional details with respect to IBM's collection, use, and handling of business contact and account usage information. When Licensee provides information to IBM and notice to, or consent by, the individuals is required for such processing, Licensee will notify individuals and obtain consent.
+
+e. IBM Business Partners who use or make available Programs are independent from IBM and unilaterally determine their prices and terms. IBM is not responsible for their actions, omissions, statements, or offerings.
+
+f. IBM may offer Non-IBM Programs, or an IBM Program may enable access to Non-IBM Programs, that may require acceptance of third party terms identified in a TD or presented to the Licensee. Linking to or use of Non-IBM Programs constitutes Licensee's agreement with such terms. IBM is not a party to any third party agreement and is not responsible for such Non-IBM Programs.
+
+g. License grants to Programs are provided by International Business Machines Corporation, a New York corporation ("IBM Corporation"). The IBM company from which the Licensee acquires entitlements ("IBM") is acting as a distributor and delivering Programs and is responsible for enforcing the terms of this Agreement. If entitlements are acquired from an IBM Business Partner, the IBM company for the country of acquisition is responsible for enforcing the terms of this Agreement. No right or cause of action is created in favor of Licensee against IBM Corporation. Licensee waives all claims and causes of action against IBM Corporation and agrees to look solely to IBM for any rights and remedies in connection with Programs.
+
+h. Licensee may not sublicense, assign, or transfer the license for any Program (except to the extent assignment or transfer may not be legally restricted or as is expressly permitted in a TD or as otherwise agreed by IBM). IBM may assign its rights and obligations under this Agreement in conjunction with the sale of the portion of IBM's business that includes a Program. IBM may share this Agreement and related documents in conjunction with any assignment.
+
+i. All notices under the Agreement must be in writing and sent to the business address specified in the agreement Licensee acquired the license entitlements unless a party designates in writing a different address. The parties consent to the use of electronic means and facsimile transmissions for communications as a signed writing. Any reproduction of the Agreement made by reliable means is considered an original. Agreement supersedes any course of dealing, discussions or representations, between the parties.
+
+j. No right or cause of action for any third party is created by the Agreement. Neither party will bring a legal action arising out of or related to the Agreement more than two years after the cause of action arose. Neither party is responsible for failure to fulfill its non-monetary obligations due to causes beyond its control. Each party will allow the other reasonable opportunity to comply before it claims the other has not met its obligations.
+
+k. IBM may use personnel and resources in locations worldwide, including third party contractors to support the delivery of Programs and Program support. Licensee's use of Programs may result in the transfer of Content, including personally identifiable information, across country borders to provide Program support as described in the IBM Software Support Guide.
+
+Part 2 - Country Required Terms
+
+For licenses acquired in the countries specified below, the following terms replace or modify the referenced terms of this IPLA. Terms not changed by these amendments remain unchanged and in effect.
+
+1. AMERICAS
+
+Section 3. Charges, Taxes, Payment, and Verification
+
+Replace the first and second sentence of paragraph b with the following:
+
+In Brazil: Licensee agrees to pay all applicable charges for acquired entitlements and any charges for use in excess of authorizations and any customs or other duty, tax, and similar levies imposed by any authority resulting from Licensee's acquisition of entitlements.
+
+In paragraph b:
+
+In Mexico: In the third sentence, delete the words "to an account specified by IBM".
+
+In Mexico: Add the following new sentence after the third sentence:
+
+Payments will be made through electronic transfer of funds to an account specified by IBM or in IBM's domicile which is located in Alfonso Napoles Gandara 3111, Santa Fe Peña Blanca, Alvaro Obregon, Mexico City, Zip Code 01210.
+
+Add at the end of paragraph c the following sentence:
+
+In Canada: Where taxes are based upon the location(s) receiving the benefit of the Program, Licensee has an ongoing obligation to notify IBM of such location(s) if different than Licensee's business address listed in the applicable TD.
+
+Add at the end of paragraph c the following sentence:
+
+In United States: The parties agree no tangible personal property (e.g. media or publications) shall transfer to Licensee if: i) IBM delivers Programs electronically to Licensee; or ii) Licensee claims a sales or use tax exemption for Programs IBM delivers electronically to Licensee. Where taxes are based upon the location(s) receiving the benefit of the Program, Licensee has an ongoing obligation to notify IBM of such location(s) if different than Licensee's business address listed in the applicable TD.
+
+Section 4. Liability and Intellectual Property Protection
+
+Insert the following disclaimer at the end of paragraph a:
+
+In Peru: In accordance with Article 1328 of the Peruvian Civil Code this limitations and exclusions will not apply in the cases of willful misconduct ("dolo") or gross negligence ("culpa inexcusable").
+
+Section 6. Governing Laws and Geographic Scope
+
+In paragraph a, replace the first sentence only with:
+
+In Argentina: Both parties agree to the application of the laws of the Republic of Argentina, without regard to the conflict of law principles. Any proceeding regarding the rights, duties, and obligations arising from this Agreement will be brought in the Ordinary Commercial Court of the City of "Ciudad Autónoma de Buenos Aires".
+
+In Chile: Both parties agree to the application of the laws of Chile, without regard to the conflict of law principles. Any conflict, interpretation or breach related to this Agreement that cannot be solved by the Parties should be remitted to the jurisdiction of the Ordinary Courts of the city and district of Santiago.
+
+In Colombia: Both parties agree to the application of the laws of the Republic of Colombia, without regard to the conflict of law principles. All rights, duties and obligations are subject to the judges of the Republic of Colombia.
+
+In Ecuador: Both parties agree to the application of the laws of the Republic of Ecuador, without regard to the conflict of law principles. Any dispute arising out or relating to this Agreement will be submitted to the civil judges of Quito and to the verbal summary proceeding.
+
+In Venezuela: Both parties agree to the application of the laws of Venezuela, without regard to the conflict of law principles. The parties agree to submit any conflict related to this Agreement, existing between them to the Courts of the Metropolitan Area of the City of Caracas.
+
+In Peru: Both parties agree to the application of the laws of Peru, without regard to the conflict of law principles. Any discrepancy that may arise between the parties in the execution, interpretation or compliance of this Agreement that may not be directly resolved shall be submitted to the Jurisdiction and Competence of the Judges and Tribunals of the 'Cercado de Lima' Judicial District.
+
+In Uruguay: Both parties agree to the application of the laws of Uruguay. Any discrepancy that may arise between the parties in the execution, interpretation or compliance of this Agreement that may not be directly resolved shall be submitted to the Montevideo Courts ("Tribunales Ordinarios de Montevideo").
+
+In paragraph a, first sentence only, replace the phrase, "the country where the transaction for license entitlements is performed" with:
+
+In United States, Anguilla, Antigua/Barbuda, Aruba, Bahamas, Barbados, Bermuda, Bonaire, British Virgin Islands, Cayman Islands, Curacao, Dominica, Grenada, Guyana, Jamaica, Montserrat, Saba, Saint Eustatius, Saint Kitts and Nevis, Saint Lucia, Saint Maarten, Saint Vincent and the Grenadines, Suriname, Tortola, Trinidad and Tobago, and Turk and Caicos: the State of New York, United States.
+
+In Canada: the Province of Ontario and the federal laws of Canada applicable therein.
+
+In paragraph a, second sentence, replace the phrase, "the country where the transaction to acquire license entitlements is performed" with:
+
+In Argentina: Argentina
+
+In Chile: Chile
+
+In Colombia: Colombia
+
+In Ecuador: Ecuador
+
+In Mexico: Mexico
+
+In Peru: Peru
+
+In Uruguay: Uruguay
+
+In Venezuela: Venezuela
+
+Add the following sentences at the end of paragraph b:
+
+In Brazil: All disputes arising out of or related to this Agreement, including summary proceedings, will be brought before and subject to the exclusive jurisdiction of the Forum of the City of São Paulo, State of São Paulo, Brazil and the parties irrevocably agree with this specific jurisdiction renouncing any other, however privileged it may be.
+
+In Mexico: The Parties agree to submit themselves to the exclusive jurisdiction of the courts of Mexico City to resolve any dispute arising from this Agreement. The Parties waive to any other jurisdiction that may correspond to them due to their current or future domiciles, or for any other reason.
+
+Section 7. General
+
+In paragraph g:
+
+In United States: delete the last 2 sentences.
+
+In paragraph i, add the following new sentence after the first sentence:
+
+In Mexico: Any change of address must be notified 10 (ten) days in advance, otherwise the notifications made at the last indicated address will have full legal effects.
+
+In paragraph j:
+
+In Brazil: delete the entire 2nd sentence of "Neither party will bring a legal action arising out of or related to the Agreement more than two years after the cause of action arose".
+
+Add as a new paragraph l to this section:
+
+In Canada: Both parties agree to write this document in English. Les parties ont convenu de rédiger le présent document en langue anglaise.
+
+2. ASIA PACIFIC
+
+Section 2. Warranties
+
+Add at the end of this section as a new paragraph f:
+
+In Australia: These warranties are in addition to any rights under, and only limited to the extent permitted by, the Competition and Consumer Act 2010.
+
+In Japan: IBM's liability is limited to this paragraph and the Liability and Intellectual Property Protection section, applicable TDs as Licensee's sole remedy for failure to meet the warranties specified in this section.
+
+In New Zealand: These warranties are in addition to any rights under the Consumer Guarantee Act 1993 or other legislation that cannot be limited by law.
+
+Section 3. Charges, Taxes, Payment, and Verification
+
+In paragraph b. replace the third sentence with the following 2 sentences:
+
+In Hong Kong, Indonesia, Korea, Macau, Malaysia, Philippines, Singapore, and Vietnam: Amounts are due upon receipt of the invoice from IBM and payable within 30 days of the invoice date to an account specified by IBM. If payment is not received within 30 days from the invoice date, IBM may charge a late payment fee on the amount outstanding, calculated on the number of days the payment is received late, at the lesser of: i) 2% for every 30 day period or portion thereof; or ii) the maximum amount permissible by applicable law.
+
+In Thailand: Amounts are due upon receipt of the invoice from IBM and payable within 30 days of the invoice date to an account specified by IBM. If payment is not received within 30 days from the invoice date, a late payment fee may be applied on the amount outstanding, at the rate of 1.25% per month, calculated on the number of days the payment is received late.
+
+In the first sentence of paragraph c, remove the word "and" before "(iv)", and add a semicolon and the following new item "(v)":
+
+In India: ; and (v) file accurate Taxes Deducted at Source (TDS) returns on a timely basis. If any tax, duty, levy or fee ("Taxes") are not charged on the basis of the exemption documentation provided by the Licensee and the taxation authority subsequently rules that such Taxes should have been charged, then the Licensee will be liable to pay such Taxes, including any interests, levies and/or penalties applicable thereon.
+
+In the first sentence of paragraph c, remove the word "and" before "(iv)", and replace item (iv) and add new item (v) with:
+
+In Singapore, Malaysia, Philippines, Thailand, Indonesia, and Vietnam: (iv) fully cooperate with IBM in seeking a waiver or reduction of withholding or other tax that Licensee requests a waiver or reduction; and v) promptly complete, file, and keep current all relevant documents for any such waiver, reductions, or exemptions.
+
+Section 4. Liability and Intellectual Property Protection
+
+In paragraph a, add at the end of the first sentence the following:
+
+In Australia: (for example, whether based in contract, tort, negligence, under statute or otherwise)
+
+In paragraph a, second sentence after the word "special" and before the word "incidental", add the following:
+
+In Philippines: (including nominal and exemplary damages), moral,
+
+Add as a new paragraph after the end of paragraph a (and ensure paragraphs properly reletter):
+
+In Australia: Where IBM is in breach of a guarantee implied by the Competition and Consumer Act 2010, IBM's liability is limited to the repair or replacement of goods or the supply of equivalent goods, or the payment of the cost of replacing the goods or having the good repaired. Where a guarantee relates to the right to sell, quiet possession, or clear title of a good under schedule 2 of the Competition and Consumer Act, then none of these limitations apply.
+
+Section 5. Termination
+
+Add at the end of the section as a new paragraph b:
+
+In Indonesia: The parties waive article 1266 of the Indonesian Civil Code to the extent it requires a court decree for the termination of an agreement creating mutual obligations.
+
+Section 6. Governing Laws and Geographic Scope
+
+In paragraph a, in the first sentence only, replace the phrase, "the country where the transaction for license entitlements is performed" with:
+
+In Cambodia, Laos: the State of New York, United States
+
+In Australia: the State or Territory in which the transaction is performed
+
+In Hong Kong: the Hong Kong Special Administrative Region of the People's Republic of China
+
+In Macau: the Hong Kong Special Administrative Region of the People's Republic of China
+
+In Korea: the Republic of Korea, and subject to the Seoul Central District Court of the Republic of Korea
+
+In Taiwan: Taiwan
+
+In India: India
+
+In paragraph a, in the second sentence, replace the phrase "the country where the transaction to acquire license entitlements is performed or, if IBM agrees, the country where the Program is placed in productive use" with:
+
+In Hong Kong: the Hong Kong Special Administrative Region of the People's Republic of China
+
+In Macau: the Macau Special Administrative Region of the People's Republic of China
+
+In Taiwan: Taiwan
+
+In paragraph b, in the first sentence, item ii), after the word "including" and before words "the defense", add:
+
+In Japan: those of Japan laws and
+
+Add at the end of the section as a new paragraph d:
+
+In Cambodia, Laos, Philippines, and Sri Lanka: Disputes will be finally settled by arbitration in Singapore under the Arbitration Rules of the Singapore International Arbitration Center ("SIAC Rules").
+
+In India: Disputes shall be finally settled in accordance with The Arbitration and Conciliation Act, 1996 then in effect, in English, with seat in Bangalore, India. There shall be one arbitrator if the amount in dispute is less than or equal to Indian Rupee five crores and three arbitrators if the amount is more. When an arbitrator is replaced, proceedings shall continue from the stage they were at when the vacancy occurred.
+
+In Indonesia: Disputes will be finally settled by arbitration in Jakarta, Indonesia, administered by the Indonesian National Board of Arbitration established in the year 1977 ("Badan Arbitrase Nasional Indonesia" or "BANI") in accordance with the rules of the Indonesian National Board of Arbitration The arbitration award shall be final and binding on the parties without appeal and shall be in writing and set forth the findings of fact and the conclusion of law.
+
+In People's Republic of China: Either party has the right to submit the dispute to the China International Economic and Trade Arbitration Commission in Beijing, the PRC, for arbitration. The parties agree three arbitrators will be used to resolve any dispute.
+
+In Vietnam: Disputes will be finally settled by arbitration in Vietnam under the Arbitration Rules of the Vietnam International Arbitration Centre ("VIAC Rules"). All proceedings and documents presented will be in the English language.
+
+Section 7. General
+
+In paragraph j, in the second sentence, replace the phrase "two years" with:
+
+In India: three years
+
+Add to the end of this section the following new paragraph l:
+
+In Indonesia: This agreement is made in the English and Bahasa Indonesian language versions. To the extent permitted by the applicable law, the English version will prevail in the event of conflict between such versions.
+
+3. EUROPE, MIDDLE EAST, AND AFRICA
+
+Section 2. Warranties
+
+In paragraph d, Replace the fourth sentence with the following two sentences:
+
+In Czech Republic, Estonia, and Lithuania: Non-IBM Programs are provided as-is, without warranties of any kind or liabilities for defects. The parties hereby exclude any liability of IBM for defects beyond the agreed warranties.
+
+Section 3. Charges, Taxes, Payment, and Verification
+
+In paragraph b, add the following to the end of the third sentence:
+
+In Italy: if IBM requests in a written notice to Licensee.
+
+In Ukraine: , on the overdue amount from the next day after the due date up to the date of actual payment, prorated for each day of delay, at the interest rate of double the discount rate determined by the National Bank of Ukraine (NBU) during the delay period (paragraph 6 of article 232 of Commercial Code of Ukraine does not apply).
+
+In paragraph b, replace the third sentence with the following:
+
+In France: Amounts are due and payable within 10 days of the invoice date to an account specified by IBM and late payment fees apply equal to the most recent European Central Bank rate plus 10 points, in addition to debt collection costs of forty (40) euros or, if these costs exceed forty euros, complementary indemnification subject to justification of the amount claimed).
+
+In Russia: Amounts are due upon receipt of the invoice and payable within 30 days of the invoice date through electronic transfer of funds to an account specified by IBM. Late payment fees at the rate of 24% per annum calculated for each day beyond the 30 days may apply.
+
+In paragraph b, add the following to the end of the last sentence:
+
+In Lithuania: , or except as provided by law
+
+At the end of paragraph b, add the following:
+
+In Italy: In the instance of no payment or partial payment, and also following a formal credit claim procedure or trial that IBM may initiate, in derogation of article 4 of Legislative Decree n. 231 dated October 9, 2002, and according to article 7 of the same Legislative Decree, IBM will notify Licensee in writing by registered, return receipt mail of late payment fees due.
+
+Section 4. Liability and Intellectual Property Protection
+
+In paragraph a, in the first sentence insert the following before the words "the amounts paid":
+
+In Belgium, France, Germany, Italy, Luxembourg, Malta, Portugal, and Spain: the greater of €500,000 (five hundred thousand euro) or
+
+In Ireland and United Kingdom: 125% of
+
+In paragraph a, in the first sentence, replace the phrase "direct damages incurred by Licensee" with:
+
+In Spain: and proven damages incurred by Licensee as a direct consequence of the IBM default
+
+In paragraph a, insert after the first sentence the following new sentence:
+
+In Slovakia: Referring to § 379 of the Commercial Code, Act No. 513/1991 Coll. as amended, and concerning all conditions related to the conclusion of the agreement, both parties state that the total foreseeable damage, which may accrue, shall not exceed the amount above, and it is the maximum for which IBM is responsible.
+
+In paragraph a, insert before the second sentence the following new sentence:
+
+In Russia: IBM will not be liable for the forgone benefit.
+
+In paragraph a, in the second sentence, delete the word:
+
+In Ireland and United Kingdom: economic
+
+In paragraph a, replace the second sentence with:
+
+In Belgium, Netherlands, and Luxembourg: IBM will not be liable for indirect or consequential damages, lost profits, business, value, revenue, goodwill, damage to reputation or anticipated savings, any third party claim against Licensee, and loss of (or damage to) data.
+
+In France: IBM will not be liable for damages to reputation, indirect damages, or lost profits, business, value, revenue, goodwill, or anticipated savings.
+
+In Portugal: IBM will not be liable for indirect damages, including loss of profit.
+
+In Spain: IBM will not be liable for damage to reputation, lost profits, business, value, revenue, goodwill, or anticipated savings.
+
+Add the following at the end of paragraph a:
+
+In France: The terms of the Agreement, including financial terms, were established in consideration of the present clause, which is an integral part of the general economy of the Agreement.
+
+In paragraph b, replace "and ii) damages that cannot be limited under applicable law" with the following:
+
+In Germany: ; ii) damages for body injury (including death); iii) loss or damage caused by a breach of guarantee assumed by IBM in connection with any transaction under this Agreement; and iv) caused intentionally or by gross negligence.
+
+Section 6. Governing Laws and Geographic Scope
+
+In paragraph a, first sentence only, replace the phrase "the country where the transaction for license entitlements is performed" with:
+
+In Albania, Armenia, Azerbaijan, Belarus, Bosnia-Herzegovina, Bulgaria, Croatia, Former Yugoslav Republic of Macedonia, Georgia, Kazakhstan, Kyrgyzstan, Moldova, Montenegro, Romania, Russia, Serbia, Tajikistan, Turkmenistan, Ukraine, and Uzbekistan: Austria
+
+In Estonia, Latvia, and Lithuania: Finland
+
+In Algeria, Andorra, Benin, Burkina Faso, Burundi, Cameroon, Cape Verde, Central African Republic, Chad, Comoros, Congo Republic, Djibouti, Democratic Republic of Congo, Equatorial Guinea, French Guiana, French Polynesia, Gabon, Guinea, Guinea-Bissau, Ivory Coast, Lebanon, Madagascar, Mali, Mauritania, Mauritius, Mayotte, Morocco, New Caledonia, Niger, Reunion, Senegal, Seychelles, Togo, Tunisia, Vanuatu, and Wallis and Futuna: France
+
+In Angola, Bahrain, Botswana, Egypt, Eritrea, Ethiopia, Gambia, Ghana, Iraq, Jordan, Kenya, Kuwait, Liberia, Malawi, Malta, Mozambique, Nigeria, Oman, Pakistan, Qatar, Rwanda, Sao Tome and Principe, Saudi Arabia, Sierra Leone, Somalia, Tanzania, Uganda, United Arab Emirates, West Bank/Gaza, Yemen, Zambia, and Zimbabwe: England
+
+In Liechtenstein: Switzerland
+
+In South Africa, Namibia, Lesotho, and Swaziland: the Republic of South Africa
+
+In United Kingdom: England
+
+In paragraph a, add the following at the end of the first sentence:
+
+In France: The Parties agree that articles 1222 and 1223 of the French Civil Code are not applicable.
+
+Add the following at the end of paragraph a:
+
+In Albania, Armenia, Azerbaijan, Belarus, Bosnia-Herzegovina, Bulgaria, Croatia, Former Yugoslav Republic of Macedonia, Georgia, Kazakhstan, Kosovo, Kyrgyzstan, Moldova, Montenegro, Romania, Russia, Serbia, Tajikistan, Turkmenistan, Ukraine, and Uzbekistan: All disputes arising out of this Agreement shall be finally settled by the International Arbitral Centre of the Austrian Federal Economic Chamber (Arbitration Body), under the Rules of Arbitration of that Arbitral Centre (Vienna Rules), in Vienna, Austria, with English as the official language, by three impartial arbitrators appointed in accordance with the Vienna Rules. Each party will nominate one arbitrator, who will jointly appoint an independent chairman within 30 days or else the chairman will be appointed by the Arbitration Body under the Vienna Rules. The arbitrators will have no authority to award injunctive relief or damages excluded by or exceeding limits in this Agreement. Nothing in this Agreement will prevent either party from resorting to judicial proceedings for (1) interim relief to prevent material prejudice or a breach of confidentiality provisions or intellectual property rights, or (2) determining the validity or ownership of any copyright, patent or trademark owned or asserted by a party or its Enterprise company, or (3) debt collection in amounts below USD 500,000.00.
+
+In Estonia, Latvia, and Lithuania: All disputes arising out of this Agreement shall be finally settled by the Arbitration Institute of the Finland Chamber of Commerce (FAI) (Arbitration Body), under the Arbitration Rules of the Finland Chamber of Commerce (Rules), in Helsinki, Finland, with English as the official language, by three impartial arbitrators appointed in accordance with those Rules. Each party will nominate one arbitrator, who will jointly appoint an independent chairman within 30 days or else the chairman will be appointed by the Arbitration Body under the Rules. The arbitrators will have no authority to award injunctive relief or damages excluded by or exceeding limits in this Agreement. Nothing in this Agreement will prevent either party from resorting to judicial proceedings for (1) interim relief to prevent material prejudice or a breach of confidentiality provisions or intellectual property rights, or (2) determining the validity or ownership of any copyright, patent or trademark owned or asserted by a party or its Enterprise company, or (3) debt collection in amounts below USD 500,000.00.
+
+In Afghanistan, Angola, Bahrain, Botswana, Burundi, Cape Verde, Djibouti, Egypt, Eritrea, Ethiopia, Gambia, Ghana, Iraq, Jordan, Kenya, Kuwait, Lebanon, Liberia, Libya, Madagascar, Malawi,, Mozambique, Nigeria, Oman, Pakistan, Palestinian Territory, Qatar, Rwanda, Sao Tome and Principe, Saudi Arabia, Seychelles, Sierra Leone, Somalia, South Sudan, Tanzania, Uganda, United Arab Emirates, Western Sahara, Yemen, Zambia, and Zimbabwe: All disputes arising out of this Agreement shall be finally settled by the London Court of International Arbitration (LCIA) (Arbitration Body), under the LCIA Arbitration Rules (the Rules), in London, UK, with English as the official language, by three impartial arbitrators appointed in accordance with the Rules. Each party will nominate one arbitrator, who will jointly appoint an independent chairman within 30 days or else the chairman will be appointed by the Arbitration Body under the Rules. The arbitrators will have no authority to award injunctive relief or damages excluded by or exceeding limits in this Agreement. Nothing in this Agreement will prevent either party from resorting to judicial proceedings for (1) interim relief to prevent material prejudice or a breach of confidentiality provisions or intellectual property rights, or (2) determining the validity or ownership of any copyright, patent or trademark owned or asserted by a party or its Enterprise company, or (3) debt collection in amounts below USD 500,000.00.
+
+In Algeria, Benin, Burkina Faso, Cameroon, Central African Republic, Chad, Congo Republic, Democratic Republic of Congo, Equatorial Guinea, French Guiana, French Polynesia, Gabon, Guinea, Guinea-Bissau, Ivory Coast, Mali, Mauritania, Mauritius, Morocco, Niger, Senegal, Togo, and Tunisia: All disputes arising out of this Agreement shall be finally settled by the ICC International Court of Arbitration, in Paris (Arbitration Body), under its arbitration rules (the Rules), in Paris, France, with French as the official language, by three impartial arbitrators appointed in accordance with the Rules. Each party will nominate one arbitrator, who will jointly appoint an independent chairman within 30 days or else the chairman will be appointed by the Arbitration Body under the Rules. The arbitrators will have no authority to award injunctive relief or damages excluded by or exceeding limits in this Agreement. Nothing in this Agreement will prevent either party from resorting to judicial proceedings for (1) interim relief to prevent material prejudice or a breach of confidentiality provisions or intellectual property rights, or (2) determining the validity or ownership of any copyright, patent or trademark owned or asserted by a party or its Enterprise company, or (3) debt collection in amounts below USD 250,000.00.
+
+In South Africa, Namibia, Lesotho, and Swaziland: All disputes arising out of this Agreement shall be finally settled by the Arbitration Foundation of Southern Africa (AFSA) (Arbitration Body), under the Rules of the Arbitration of the AFSA (the Rules), in Johannesburg, South Africa, with English as the official language, by three impartial arbitrators appointed in accordance with the Rules. Each party will nominate one arbitrator, who will jointly appoint an independent chairman within 30 days or else the chairman will be appointed by the Arbitration Body under the Rules. The arbitrators will have no authority to award injunctive relief or damages excluded by or exceeding limits in this Agreement. Nothing in this Agreement will prevent either party from resorting to judicial proceedings for (1) interim relief to prevent material prejudice or a breach of confidentiality provisions or intellectual property rights, or (2) determining the validity or ownership of any copyright, patent or trademark owned or asserted by a party or its Enterprise company, or (3) debt collection in amounts below USD 250,000.00.
+
+In Andorra, Austria, Cyprus, France, Germany, Greece, Israel, Italy, Portugal, Spain, Switzerland, and Turkey: All disputes will be brought before and subject to the exclusive jurisdiction of the following court of competent jurisdiction:
+
+In Andorra: the Commercial Court of Paris.
+
+In Austria: the court of Vienna, Austria (Inner City).
+
+In Cyprus: the competent court of Nicosia.
+
+In France: Commercial Court of Paris.
+
+In Germany: the courts of Stuttgart.
+
+In Greece: the competent court of Athens.
+
+In Israel: the courts of Tel Aviv Jaffa.
+
+In Italy: the courts of Milan.
+
+In Portugal: the courts of Lisbon.
+
+In Spain: the courts of Madrid.
+
+In Switzerland: the commercial court of the canton of Zurich.
+
+In Turkey: the Istanbul Central (Caglayan) Courts and Execution Directorates of Istanbul, the Republic of Turkey.
+
+In Netherlands: The Parties waive their rights under Title 7.1 ('Koop') and clause 7:401 and 402 of the Dutch Civil Code, and their rights to invoke a full or partial dissolution ('gehele of partiele ontbinding') of this Agreement under section 6:265 of the Dutch Civil Code.
+
+Section 7. General
+
+In paragraph d, insert the following at the end of the paragraph:
+
+In Spain: IBM will comply with requests to access, update or delete contact information if submitted to the following address: IBM, c/ Santa Hortensia 26-28, 28002 Madrid, Departamento de Privacidad de Datos.
+
+In paragraph j, add to the end the paragraph:
+
+In Czech Republic: Pursuant to Section 1801 of Act No. 89/2012 Coll. (the "Civil Code"), Section 1799 and Section 1800 of the Civil Code as amended, do not apply to transactions under this Agreement. Licensee accepts the risk of a change of circumstances under Section 1765 of the Civil Code.
+
+In paragraph j:
+
+In Bulgaria, Croatia, Russia, Serbia, and Slovenia: delete the 2nd sentence that says: "Neither party will bring a legal action arising out of or related to the Agreement more than two years after the cause of action arose".
+
+In paragraph j, add to the end of the second sentence:
+
+In Lithuania: , except as provided by law
+
+In paragraph j, replace the second sentence with:
+
+In Poland: Neither party will bring a legal action arising out of or related to the Agreement more than three years after the cause of action arose, except for an action of non-payment which will be brought no more than 2 years after payment is due.
+
+In paragraph j, second sentence, replace the word "two" with:
+
+In Latvia and Ukraine: three
+
+In Slovakia: four
+
+In paragraph j, add to the end of the third sentence that says: "Neither party is responsible for failure to fulfill its non-monetary obligations due to causes beyond its control":
+
+In Russia: , including but not limited to earthquakes, floods, fires, acts of God, strikes (excluding strikes of the parties' employees), acts of war, military actions, embargoes, blockades, international or governmental sanctions, and acts of authorities of the applicable jurisdiction.
+
+In paragraph j, third sentence, modify the sentence: "Neither party is responsible for failure to fulfill its non-monetary obligations due to causes beyond its control" as follows:
+
+In Ukraine: Neither party is responsible for failure to fulfill its non-monetary obligations due to causes or regulatory changes beyond its control, including but not limited to import, export and economic sanctions requirements of the United States.
+
+Add the following at the end of the section as new paragraph l:
+
+In Hungary: By entering into this Agreement, Licensee confirms that Licensee was sufficiently informed of all the provisions of this Agreement and had the opportunity to negotiate those terms. The following provisions may significantly deviate from the provisions generally applied by Hungarian law and both parties accept those provisions by signing the Agreement: Program License; Warranties; Charges, Taxes, Payment, and Verification; Liability and Intellectual Property Protection; Termination; Governing Laws and Geographic Scope; and General.
+
+In Czech Republic: Licensee expressly accepts the terms of this agreement which include the following important commercial terms: i) limitation and disclaimer of liability for defects (Warranties); ii) limitation of Licensee's entitlement to damages (Liability and Intellectual Property Protection); iii) binding nature of export and import regulations (Governing Laws and Geographic Scope); iv) shorter limitation periods (General); v) exclusion of applicability of provisions on adhesion contracts (General); and vi) acceptance of the risk of a change of circumstances (General).
+
+In Romania: The Licensee expressly accepts, the following standard clauses that may be deemed 'unusual clauses' as per the provisions of article 1203 Romanian Civil Code: clauses 2, 4, 5, 8j. The Licensee hereby acknowledges that it was sufficiently informed of all the provisions of this Agreement, including the clauses mentioned above, it properly analyzed and understood such provisions and had the opportunity to negotiate the terms of each clause.
+
+i125-3301-15 (10-2021)
+
+-----
+
+LICENSE INFORMATION
+
+The Programs listed below are licensed under the following License Information terms and conditions in addition to the Program license terms previously agreed to by Client and IBM. If Client does not have previously agreed to license terms in effect for the Program, the International License Agreement for Evaluation of Programs (i125-5543-06) applies.
+
+Program Name (Program Number):
+IBM Watson Speech to Text Library for Embed 1.0.0 (Evaluation)
+
+The following standard terms apply to Licensee's use of the Program.
+
+Evaluation Period
+
+The evaluation period begins on the date that Licensee agrees to the terms of this Agreement and ends after 180 days.
+
+Modifiable Third Party Code
+
+To the extent, if any, in the NOTICES file IBM identifies third party code as "Modifiable Third Party Code," IBM authorizes Licensee to 1) modify the Modifiable Third Party Code and 2) reverse engineer the Program modules that directly interface with the Modifiable Third Party Code provided that it is only for the purpose of debugging Licensee's modifications to such third party code. IBM's service and support obligations, if any, apply only to the unmodified Program.
+
+Separately Licensed Code
+
+Each of the components listed in the NON_IBM_LICENSE file is considered "Separately Licensed Code" licensed to Licensee under the terms of the applicable third party license agreement(s) set forth in the NON_IBM_LICENSE file(s) that accompanies the Program, and not this Agreement. Future Program updates or fixes may contain additional Separately Licensed Code. Such additional Separately Licensed Code and related licenses are listed in the applicable NON_IBM_LICENSE file that accompanies the Program update or fix.
+
+Note: Notwithstanding any of the terms in the third party license agreement, the Agreement, or any other agreement Licensee may have with IBM, with respect to the Separately Licensed Code:
+(a) IBM provides it to Licensee WITHOUT WARRANTIES OF ANY KIND AND DISCLAIMS ANY AND ALL EXPRESS AND IMPLIED WARRANTIES AND CONDITIONS INCLUDING, BUT NOT LIMITED TO, THE WARRANTY OF TITLE, NON-INFRINGEMENT OR NON-INTERFERENCE, AND THE IMPLIED WARRANTIES AND CONDITIONS OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE;
+(b) IBM is not liable for any direct, indirect, incidental, special, exemplary, punitive or consequential damages including, but not limited to, lost data, lost savings, and lost profits.
+
+Benchmarking
+
+Licensee may disclose the results of any benchmark test of the Program or its subcomponents to any third party provided that Licensee (A) publicly discloses the complete methodology used in the benchmark test (for example, hardware and software setup, installation procedure and configuration files), and (B) performs testing running the Program in its Specified Operating Environment using the latest applicable updates, patches, fixes, performance tuning, and best practices guidance available for the Program,. If Licensee publishes the results of any benchmark tests for the Program, then IBM (including third parties providing IBM products "Third Parties") will have the right to publish the results of benchmark tests with respect to Licensee's products provided IBM or Third Parties complies with the requirements of (A), and (B) above in its testing of Licensee's products.
+
+Notwithstanding the foregoing, under no circumstances may Licensee publish the results of benchmark tests run on Oracle Outside In Technology without prior written permission.
+
+L/N:  L-DAJI-CJULKJ
+D/N:  L-DAJI-CJULKJ
+P/N:  L-DAJI-CJULKJ
+
+
+
+-----
+
+International License Agreement for Evaluation of Programs
+
+Part 1 - General Terms
+
+BY DOWNLOADING, INSTALLING, COPYING, ACCESSING, CLICKING ON AN "ACCEPT" BUTTON, OR OTHERWISE USING THE PROGRAM, LICENSEE AGREES TO THE TERMS OF THIS AGREEMENT. IF YOU ARE ACCEPTING THESE TERMS ON BEHALF OF LICENSEE, YOU REPRESENT THAT YOU HAVE FULL AUTHORITY TO BIND LICENSEE TO THESE TERMS.
+
+IF YOU DO NOT AGREE TO THESE TERMS OR DO NOT HAVE AUTHORITY: i) DO NOT DOWNLOAD, INSTALL, COPY, ACCESS, CLICK ON AN "ACCEPT" BUTTON, OR USE THE PROGRAM; AND ii) PROMPTLY RETURN THE UNUSED MEDIA, DOCUMENTATION, AND PROOF OF ENTITLEMENT TO THE PARTY FROM WHOM IT WAS OBTAINED FOR A REFUND OF THE AMOUNT PAID. IF THE PROGRAM WAS DOWNLOADED, DESTROY ALL COPIES OF THE PROGRAM.
+
+This International License Agreement for Evaluation of Programs (ILAE) and applicable Transaction Documents (together the "Agreement") are the complete agreement between Licensee and IBM regarding the use of a Program. The country required terms included in Part 2 of this ILAE replace or modify the terms of Part 1.
+
+Transaction Documents (TDs) provide a description, information, and terms regarding the Program and its authorized use. Examples of TDs for Programs include license information (LI), licensed program specifications (LPS), quote, proof of entitlement (PoE), or invoice. To the extent of any conflict a TD will prevail over the ILAE.
+
+1. Program License
+
+a. A Program is an executable IBM-branded computer program and its related material and includes whole and partial copies. Program details are described in a TD available at http://www.ibm.com/software/sla (for Passport Advantage Programs) or http://www.ibm.com/support/knowledgecenter (for other IBM Programs), in the Program's system command directory, or as otherwise specified by IBM. IBM software policies (such as backup, temporary use and IBM approved cloud environment) available at http://www.ibm.com/softwarepolicies apply to Licensee's use of Programs.
+
+b. Copies of Programs are copyrighted and licensed.
+
+c. Licensee is granted a nonexclusive limited license to:
+
+(1) use each copy of a Program solely for internal evaluation, testing, or demonstration purposes on a trial basis during the Evaluation Period (as defined in the applicable Program TD) ("Authorized Use");
+
+(2) make and install copies to support such Authorized Use; and
+
+(3) make a backup copy.
+
+d. Programs may be used by Licensee, its employees and contractors. Licensee may not use the Program for productive purposes, rent or lease a Program, or provide commercial IT, hosting or timesharing services to any third party. Additional rights may be available for additional fees or under different terms.
+
+e. The license granted for a Program is subject to Licensee:
+
+(1) reproducing copyright notices and other markings on any copy;
+
+(2) ensuring anyone who uses the Program: i) does so only on Licensee's behalf within Licensee's Authorized Use; and ii) complies with this Agreement;
+
+(3) not disabling any disabling device, reverse assembling, reverse compiling, translating, or reverse engineering the Program, except as expressly permitted by law without the possibility of contractual waiver; and
+
+(4) not using any of the elements of the Program or related licensed materials separately from the Program.
+
+f. If the TD for a Program ("Principal Program") states that a "Supporting Program" is included with the Principal Program, Licensee may use the Supporting Program subject to any license limitations of the Principal Program and only to support the Principal Program.
+
+g. This license applies to each copy of the Program that Licensee makes.
+
+h. An update, fix, or patch to a Program is subject to the terms governing the Program unless new terms are provided in an updated TD. Licensee accepts such new terms upon installation of the update, fix, or patch. If a Program is replaced by an update, Licensee agrees to promptly discontinue use of the replaced Program.
+
+2. Warranties
+
+a. Subject to applicable laws, Programs are provided as-is, with no warranties of any kind, including: i) no warranty for uninterrupted or error-free operation of the Program; or ii) no other warranties such as implied warranties or conditions of satisfactory quality, merchantability, non-infringement, and fitness for a particular purpose.
+
+b. IBM does not provide any support, unless otherwise specified in a TD.
+
+3. Charges, Taxes, Payment, and Verification
+
+a. There are no charges for use of a Program during the Evaluation Period, unless specified otherwise by IBM. If any authority imposes a custom, duty, tax (including withholding tax), levy or fee for the import or export, transfer, access or use of the Program, then Licensee is responsible to pay any such amount imposed.
+
+b. If Licensee imports, exports, transfers, accesses, or uses a Program across a border, Licensee agrees to be responsible for and pay authorities any custom, duty, tax, or similar levy assessed by the authorities. This excludes those taxes based on IBM's net income.
+
+3.1 Licensing Verification
+
+a. Licensee will, for all Programs at all sites and for all environments, create, retain, and provide to IBM upon request with 30 days' advance notice: i) a report, in a format requested by IBM using records, system tools output, and other system information; and ii) supporting documentation (collectively, "Deployment Data").
+
+b. Upon reasonable notice, IBM and its independent auditors may verify Licensee's compliance with this Agreement, at all sites and for all environments in which Licensee uses (for any purposes) Programs. Verification will be conducted in a manner that minimizes disruption to Licensee's business and may be conducted on Licensee's premises, during normal business hours. IBM will have a written confidentiality agreement with the independent auditor. In addition to providing Deployment Data described above, Licensee agrees to provide to IBM and its auditors additional accurate information and Deployment Data upon request.
+
+c. Licensee will promptly order and pay charges at IBM's then current rates associated with: i) any deployments or use in excess of authorizations or in violation of this agreement indicated on or by any verification; ii) applicable subscription & support services (S&S) for such excess deployments for the lesser of the duration of such excess use or two years; and iii) any additional charges and other liabilities determined as a result of such verification, including but not limited to taxes, duties, and regulatory fees.
+
+4. Liability
+
+a. IBM's entire liability for all claims related to the Agreement will not exceed the amount of any actual direct damages incurred by Licensee up to the greater of: i) U.S. $10,000.00 (or equivalent in local currency); or ii) the amounts paid (if recurring charges, up to 12 months' charges apply) for the entitlements to the Program that is the subject of the claim, regardless of the basis of the claim. IBM will not be liable for special, incidental, exemplary, indirect, or economic consequential damages, or for lost profits, business, value, revenue, goodwill, or anticipated savings. These limitations apply collectively to IBM, its affiliates, contractors, and suppliers.
+
+b. The following amounts are not subject to the above cap: damages that cannot be limited under applicable law.
+
+c. IBM has no responsibility for claims based on non-IBM products, items not provided by IBM, or any violation of law or third party rights caused by Content, or any Licensee materials, designs, specifications. Content consists of all data, software, and information that Licensee or its authorized users provide, authorize access to, or inputs to a Program.
+
+5. Termination
+
+a. The Evaluation Period begins on the date Licensee agrees to the terms of this Agreement and ends upon the earliest of: i) the date specified in the applicable TD; or ii) the date on which the Program automatically disables itself. Licensee will destroy the Program and all copies made of it within ten days of the end of the Evaluation Period. Licensee is responsible to remove any Content prior to expiration of the Evaluation Period as any disabling device may prevent use upon expiration.
+
+b. If IBM specifies in a TD that Licensee may retain the Program, and Licensee elects to do so, then the Program will be subject to a different license agreement, which IBM will provide to Licensee. In addition, a charge may apply.
+
+c. IBM may terminate Licensee's license to use a Program if Licensee fails to comply with the ILAE, TDs or acquisition agreements, such as the International Passport Advantage Agreement (IPAA). Licensee will promptly destroy all copies of the Program after license termination. Any terms that by their nature extend beyond the termination remain in effect until fulfilled and apply to successors and assignees.
+
+6. Governing Laws and Geographic Scope
+
+a. Both parties agree to the application of the laws of the country where the transaction for license entitlements is performed, without regard to conflict of law principles. The rights and obligations of each party are valid only in the country where the transaction to acquire license entitlements is performed or, if IBM agrees, the country where the Program is placed in productive use, except all licenses are valid as specifically granted.
+
+b. Each party is also responsible for complying with: i) laws and regulations applicable to its business and Content; and ii) import, export and economic sanction laws and regulations, including the defense trade control regime of the United States of America and any applicable jurisdictions, that prohibit or restrict the import, export, re-export, or transfer of products, technology, services or data, directly or indirectly, to or for certain countries, end uses or end users.
+
+c. If any provision of this Agreement for a Program, is invalid or unenforceable, the remaining provisions remain in full force and effect. Nothing in this Agreement affects statutory rights of consumers that cannot be waived or limited by contract. The United Nations Convention on Contracts for the International Sale of Goods does not apply to transactions under this Agreement.
+
+7. General
+
+a. IBM is an independent contractor, not Licensee's agent, joint venturer, partner, or fiduciary, and does not undertake to perform any of Licensee's regulatory obligations, or assume any responsibility for Licensee's business or operations. Licensee is responsible for its use of IBM Programs and Non-IBM Programs. IBM is acting as an information technology provider only. IBM's direction, suggested usage, or guidance or use of a Program does not constitute medical, clinical, legal, accounting, or other licensed professional advice. Licensee should obtain its own expert advice.
+
+b. For Programs IBM provides to Licensee in tangible form, IBM fulfills its shipping and delivery obligations upon the delivery of such Programs to the IBM-designated carrier, unless otherwise agreed to in writing by Licensee and IBM.
+
+c. Licensee may not use the Program if failure of the Program could lead to death, serious bodily injury, or property or environmental damage.
+
+d. IBM, its affiliates, and contractors of either require use of business contact information and certain account usage information. This information is not Content. Business contact information is used to communicate and manage business dealings with the Licensee. Examples of business contact information include name, business telephone, address, email, user ID, and tax registration information. Account usage information is required to enable, provide, manage, support, administer, and improve Programs. Examples of account usage information include reported errors and digital information gathered using tracking technologies, such as cookies and web beacons, during use of the Programs. The IBM Privacy Statement at https://www.ibm.com/privacy/ provides additional details with respect to IBM's collection, use, and handling of business contact and account usage information. When Licensee provides information to IBM and notice to, or consent by, the individuals is required for such processing, Licensee will notify individuals and obtain consent.
+
+e. IBM Business Partners who use or make available Programs are independent from IBM and unilaterally determine their prices and terms. IBM is not responsible for their actions, omissions, statements, or offerings.
+
+f. IBM may offer Non-IBM Programs, or an IBM Program may enable access to Non-IBM Programs, that may require acceptance of third party terms identified in a TD or presented to the Licensee. Linking to or use of Non-IBM Programs constitutes Licensee's agreement with such terms. IBM is not a party to such third party agreements and is not responsible for such Non-IBM Programs.
+
+g. License grants to Programs are provided by International Business Machines Corporation, a New York corporation ("IBM Corporation"). The IBM company from which the Licensee acquires entitlements ("IBM") is acting as a distributor and delivering Programs and is responsible for enforcing the terms of this Agreement. If entitlements are acquired from an IBM Business Partner, the IBM company for the country of acquisition is responsible for enforcing the terms of this Agreement. No right or cause of action is created in favor of Licensee against IBM Corporation. Licensee waives all claims and causes of action against IBM Corporation and agrees to look solely to IBM for any rights and remedies in connection with Programs.
+
+h. Licensee may not sublicense, assign, or transfer the license for any Program (except to the extent assignment or transfer may not be legally restricted or as is expressly permitted in a TD or as otherwise agreed by IBM). IBM may assign its rights and obligations under this Agreement in conjunction with the sale of the portion of IBM's business that includes a Program. IBM may share this Agreement and related documents in conjunction with any assignment.
+
+i. All notices under the Agreement must be in writing and sent to the business address specified in the agreement Licensee acquired the license entitlements unless a party designates in writing a different address. The parties consent to the use of electronic means and facsimile transmissions for communications as a signed writing. Any reproduction of the Agreement made by reliable means is considered an original. Agreement supersedes any course of dealing, discussions or representations, between the parties.
+
+j. No right or cause of action for any third party is created by the Agreement. Neither party will bring a legal action arising out of or related to the Agreement more than two years after the cause of action arose. Neither party is responsible for failure to fulfill its non-monetary obligations due to causes beyond its control. Each party will allow the other reasonable opportunity to comply before it claims the other has not met its obligations.
+
+k. IBM may use personnel and resources in locations worldwide, including third party contractors to support the delivery of Programs and Program support. Licensee's use of Programs may result in the transfer of Content, including personally identifiable information, across country borders to provide Program support as described in the IBM Software Support Guide.
+
+Part 2 - Country Required Terms
+
+For licenses acquired in the countries specified below, the following terms replace or modify the referenced terms of this ILAE. Terms not changed by these amendments remain unchanged and in effect.
+
+1. AMERICAS
+
+Section 4. Liability
+
+Insert the following disclaimer at the end of paragraph a:
+
+In Peru: In accordance with Article 1328 of the Peruvian Civil Code this limitations and exclusions will not apply in the cases of willful misconduct ("dolo") or gross negligence ("culpa inexcusable").
+
+Section 6. Governing Laws and Geographic Scope
+
+In paragraph a, replace the first sentence only with:
+
+In Argentina: Both parties agree to the application of the laws of the Republic of Argentina, without regard to the conflict of law principles. Any proceeding regarding the rights, duties, and obligations arising from this Agreement will be brought in the Ordinary Commercial Court of the City of "Ciudad Autónoma de Buenos Aires".
+
+In Chile: Both parties agree to the application of the laws of Chile, without regard to the conflict of law principles. Any conflict, interpretation or breach related to this Agreement that cannot be solved by the Parties should be remitted to the jurisdiction of the Ordinary Courts of the city and district of Santiago.
+
+In Colombia: Both parties agree to the application of the laws of the Republic of Colombia, without regard to the conflict of law principles. All rights, duties and obligations are subject to the judges of the Republic of Colombia.
+
+In Ecuador: Both parties agree to the application of the laws of the Republic of Ecuador, without regard to the conflict of law principles. Any dispute arising out or relating to this Agreement will be submitted to the civil judges of Quito and to the verbal summary proceeding.
+
+In Venezuela: Both parties agree to the application of the laws of Venezuela, without regard to the conflict of law principles. The parties agree to submit any conflict related to this Agreement, existing between them to the Courts of the Metropolitan Area of the City of Caracas.
+
+In Peru: Both parties agree to the application of the laws of Peru, without regard to the conflict of law principles. Any discrepancy that may arise between the parties in the execution, interpretation or compliance of this Agreement that may not be directly resolved shall be submitted to the Jurisdiction and Competence of the Judges and Tribunals of the 'Cercado de Lima' Judicial District.
+
+In Uruguay: Both parties agree to the application of the laws of Uruguay. Any discrepancy that may arise between the parties in the execution, interpretation or compliance of this Agreement that may not be directly resolved shall be submitted to the Montevideo Courts ("Tribunales Ordinarios de Montevideo").
+
+In paragraph a, first sentence only, replace the phrase, "the country where the transaction for license entitlements is performed" with:
+
+In United States, Anguilla, Antigua/Barbuda, Aruba, Bahamas, Barbados, Bermuda, Bonaire, British Virgin Islands, Cayman Islands, Curacao, Dominica, Grenada, Guyana, Jamaica, Montserrat, Saba, Saint Eustatius, Saint Kitts and Nevis, Saint Lucia, Saint Maarten, Saint Vincent and the Grenadines, Suriname, Tortola, Trinidad and Tobago, and Turk and Caicos: the State of New York, United States.
+
+In Canada: the Province of Ontario and the federal laws of Canada applicable therein.
+
+In paragraph a, second sentence, replace the phrase, "the country where the transaction to acquire license entitlements is performed " with:
+
+In Argentina: Argentina
+
+In Chile: Chile
+
+In Colombia: Colombia
+
+In Ecuador: Ecuador
+
+In Mexico: Mexico
+
+In Peru: Peru
+
+In Uruguay: Uruguay
+
+In Venezuela: Venezuela
+
+Add the following sentences at the end of paragraph b:
+
+In Brazil: All disputes arising out of or related to this Agreement, including summary proceedings, will be brought before and subject to the exclusive jurisdiction of the Forum of the City of São Paulo, State of São Paulo, Brazil and the parties irrevocably agree with this specific jurisdiction renouncing any other, however privileged it may be.
+
+In Mexico: The Parties agree to submit themselves to the exclusive jurisdiction of the courts of Mexico City to resolve any dispute arising from this Agreement. The Parties waive to any other jurisdiction that may correspond to them due to their current or future domiciles, or for any other reason.
+
+Section 7. General
+
+In paragraph g:
+
+In United States: delete the last 2 sentences.
+
+In paragraph i, add the following new sentence after the first sentence:
+
+In Mexico: Any change of address must be notified 10 (ten) days in advance, otherwise the notifications made at the last indicated address will have full legal effects.
+
+In paragraph j:
+
+In Brazil: delete the entire 2nd sentence of "Neither party will bring a legal action arising out of or related to the Agreement more than two years after the cause of action arose".
+
+Add as a new paragraph l to this section:
+
+In Canada: Both parties agree to write this document in English. Les parties ont convenu de rédiger le présent document en langue anglaise.
+
+2. ASIA PACIFIC
+
+Section 2. Warranties
+
+Add at the end of this section as a new paragraph c:
+
+In Australia: These warranties are in addition to any rights under, and only limited to the extent permitted by, the Competition and Consumer Act 2010.
+
+In Japan: IBM's liability is limited to this paragraph and the Liability section, applicable TDs as Licensee's sole remedy for failure to meet the warranties specified in this section.
+
+In New Zealand: These warranties are in addition to any rights under the Consumer Guarantee Act 1993 or other legislation that cannot be limited by law.
+
+Section 4. Liability
+
+In paragraph a, add at the end of the first sentence the following:
+
+In Australia: (for example, whether based in contract, tort, negligence, under statute or otherwise)
+
+In paragraph a, second sentence after the word "special" and before the word "incidental", add the following:
+
+In Philippines: (including nominal and exemplary damages), moral,
+
+Section 5. Termination
+
+Add at the end of the section as a new paragraph d:
+
+In Indonesia: The parties waive article 1266 of the Indonesian Civil Code to the extent it requires a court decree for the termination of an agreement creating mutual obligations.
+
+Section 6. Governing Laws and Geographic Scope
+
+In paragraph a, in the first sentence only, replace the phrase, "the country where the transaction for license entitlements is performed" with:
+
+In Cambodia, Laos: the State of New York, United States
+
+In Australia: the State or Territory in which the transaction is performed
+
+In Hong Kong: the Hong Kong Special Administrative Region of the People's Republic of China
+
+In Macau: the Hong Kong Special Administrative Region of the People's Republic of China
+
+In Korea: the Republic of Korea, and subject to the Seoul Central District Court of the Republic of Korea
+
+In Taiwan: Taiwan
+
+In India: India
+
+In paragraph b, in the first sentence, item ii), after the word "including" and before word "defense", add:
+
+In Japan: those of Japan laws and
+
+In paragraph a, in the second sentence, replace the phrase "the country where the transaction to acquire license entitlements is performed or, if IBM agrees, the country where the Program is placed in productive use" with:
+
+In Hong Kong: the Hong Kong Special Administrative Region of the People's Republic of China
+
+In Macau: the Macau Special Administrative Region of the People's Republic of China
+
+In Taiwan: Taiwan
+
+Add at the end of the section as a new paragraph d:
+
+In Cambodia, Laos, Philippines, and Sri Lanka: Disputes will be finally settled by arbitration in Singapore under the Arbitration Rules of the Singapore International Arbitration Center ("SIAC Rules").
+
+In India: Disputes shall be finally settled in accordance with The Arbitration and Conciliation Act, 1996 then in effect, in English, with seat in Bangalore, India. There shall be one arbitrator if the amount in dispute is less than or equal to Indian Rupee five crores and three arbitrators if the amount is more. When an arbitrator is replaced, proceedings shall continue from the stage they were at when the vacancy occurred.
+
+In Indonesia: Disputes will be finally settled by arbitration in Jakarta, Indonesia, administered by the Indonesian National Board of Arbitration established in the year 1977 ("Badan Arbitrase Nasional Indonesia" or "BANI") in accordance with the rules of the Indonesian National Board of Arbitration The arbitration award shall be final and binding on the parties without appeal and shall be in writing and set forth the findings of fact and the conclusion of law.
+
+In People's Republic of China: Either party has the right to submit the dispute to the China International Economic and Trade Arbitration Commission in Beijing, the PRC, for arbitration. The parties agree three arbitrators will be used to resolve any dispute.
+
+In Vietnam: Disputes will be finally settled by arbitration in Vietnam under the Arbitration Rules of the Vietnam International Arbitration Centre ("VIAC Rules"). All proceedings and documents presented will be in the English language.
+
+Section 7. General
+
+In paragraph j, in the second sentence, replace the phrase "two years" with:
+
+In India: three years
+
+Add to the end of this section the following new paragraph l:
+
+In Indonesia: This agreement is made in the English and Bahasa Indonesian language versions. To the extent permitted by the applicable law, the English version will prevail in the event of conflict between such versions.
+
+3. EUROPE, MIDDLE EAST, AND AFRICA
+
+Section 4. Liability
+
+In paragraph a, in the first sentence insert the following before the words "the amounts paid":
+
+In Belgium, France, Germany, Italy, Luxembourg, Malta, Portugal, and Spain: the greater of €500,000 (five hundred thousand euro) or
+
+In Ireland and United Kingdom: 125% of
+
+In paragraph a, in the first sentence, replace the phrase "direct damages incurred by Licensee" with:
+
+In Spain: and proven damages incurred by Licensee as a direct consequence of the IBM default
+
+In paragraph a, insert after the first sentence the following new sentence:
+
+In Slovakia: Referring to § 379 of the Commercial Code, Act No. 513/1991 Coll. as amended, and concerning all conditions related to the conclusion of the agreement, both parties state that the total foreseeable damage, which may accrue, shall not exceed the amount above, and it is the maximum for which IBM is responsible.
+
+In paragraph a, insert before the second sentence the following new sentence:
+
+In Russia: IBM will not be liable for the forgone benefit.
+
+In paragraph a, in the second sentence, delete the word:
+
+In Ireland and United Kingdom: economic
+
+In paragraph a, replace the second sentence with:
+
+In Belgium, Netherlands, and Luxembourg: IBM will not be liable for indirect or consequential damages, lost profits, business, value, revenue, goodwill, damage to reputation or anticipated savings, any third party claim against Licensee, and loss of (or damage to) data.
+
+In France: IBM will not be liable for damages to reputation, indirect damages, or lost profits, business, value, revenue, goodwill, or anticipated savings.
+
+In Portugal: IBM will not be liable for indirect damages, including loss of profit.
+
+In Spain: IBM will not be liable for damage to reputation, lost profits, business, value, revenue, goodwill, or anticipated savings.
+
+Add the following at the end of paragraph a:
+
+In France: The terms of the Agreement, including financial terms, were established in consideration of the present clause, which is an integral part of the general economy of the Agreement.
+
+In paragraph b, replace "damages that cannot be limited under applicable law" with the following:
+
+In Germany: i) damages for body injury (including death); ii) loss or damage caused by a breach of guarantee assumed by IBM in connection with any transaction under this Agreement; and iii) caused intentionally or by gross negligence.
+
+Section 6. Governing Laws and Geographic Scope
+
+In paragraph a, first sentence only, replace the phrase "the country where the transaction for license entitlements is performed" with:
+
+In Albania, Armenia, Azerbaijan, Belarus, Bosnia-Herzegovina, Bulgaria, Croatia, Former Yugoslav Republic of Macedonia, Georgia, Kazakhstan, Kyrgyzstan, Moldova, Montenegro, Romania, Russia, Serbia, Tajikistan, Turkmenistan, Ukraine, and Uzbekistan: Austria
+
+In Estonia, Latvia, and Lithuania: Finland
+
+In Algeria, Andorra, Benin, Burkina Faso, Burundi, Cameroon, Cape Verde, Central African Republic, Chad, Comoros, Congo Republic, Djibouti, Democratic Republic of Congo, Equatorial Guinea, French Guiana, French Polynesia, Gabon, Guinea, Guinea-Bissau, Ivory Coast, Lebanon, Madagascar, Mali, Mauritania, Mauritius, Mayotte, Morocco, New Caledonia, Niger, Reunion, Senegal, Seychelles, Togo, Tunisia, Vanuatu, and Wallis and Futuna: France
+
+In Angola, Bahrain, Botswana, Egypt, Eritrea, Ethiopia, Gambia, Ghana, Iraq, Jordan, Kenya, Kuwait, Liberia, Malawi, Malta, Mozambique, Nigeria, Oman, Pakistan, Qatar, Rwanda, Sao Tome and Principe, Saudi Arabia, Sierra Leone, Somalia, Tanzania, Uganda, United Arab Emirates, West Bank/Gaza, Yemen, Zambia, and Zimbabwe: England
+
+In Liechtenstein: Switzerland
+
+In South Africa, Namibia, Lesotho, and Swaziland: the Republic of South Africa
+
+In United Kingdom: England
+
+In paragraph a, add the following at the end of the first sentence:
+
+In France: The Parties agree that articles 1222 and 1223 of the French Civil Code are not applicable.
+
+Add the following at the end of paragraph a:
+
+In Albania, Armenia, Azerbaijan, Belarus, Bosnia-Herzegovina, Bulgaria, Croatia, Former Yugoslav Republic of Macedonia, Georgia, Kazakhstan, Kosovo, Kyrgyzstan, Moldova, Montenegro, Romania, Russia, Serbia, Tajikistan, Turkmenistan, Ukraine, and Uzbekistan: All disputes arising out of this Agreement shall be finally settled by the International Arbitral Centre of the Austrian Federal Economic Chamber (Arbitration Body), under the Rules of Arbitration of that Arbitral Centre (Vienna Rules), in Vienna, Austria, with English as the official language, by three impartial arbitrators appointed in accordance with the Vienna Rules. Each party will nominate one arbitrator, who will jointly appoint an independent chairman within 30 days or else the chairman will be appointed by the Arbitration Body under the Vienna Rules. The arbitrators will have no authority to award injunctive relief or damages excluded by or exceeding limits in this Agreement. Nothing in this Agreement will prevent either party from resorting to judicial proceedings for (1) interim relief to prevent material prejudice or a breach of confidentiality provisions or intellectual property rights, or (2) determining the validity or ownership of any copyright, patent or trademark owned or asserted by a party or its Enterprise company, or (3) debt collection in amounts below USD 500,000.00.
+
+In Estonia, Latvia, and Lithuania: All disputes arising out of this Agreement shall be finally settled by the Arbitration Institute of the Finland Chamber of Commerce (FAI) (Arbitration Body), under the Arbitration Rules of the Finland Chamber of Commerce (Rules), in Helsinki, Finland, with English as the official language, by three impartial arbitrators appointed in accordance with those Rules. Each party will nominate one arbitrator, who will jointly appoint an independent chairman within 30 days or else the chairman will be appointed by the Arbitration Body under the Rules. The arbitrators will have no authority to award injunctive relief or damages excluded by or exceeding limits in this Agreement. Nothing in this Agreement will prevent either party from resorting to judicial proceedings for (1) interim relief to prevent material prejudice or a breach of confidentiality provisions or intellectual property rights, or (2) determining the validity or ownership of any copyright, patent or trademark owned or asserted by a party or its Enterprise company, or (3) debt collection in amounts below USD 500,000.00.
+
+In Afghanistan, Angola, Bahrain, Botswana, Burundi, Cape Verde, Djibouti, Egypt, Eritrea, Ethiopia, Gambia, Ghana, Iraq, Jordan, Kenya, Kuwait, Lebanon, Liberia, Libya, Madagascar, Malawi,, Mozambique, Nigeria, Oman, Pakistan, Palestinian Territory, Qatar, Rwanda, Sao Tome and Principe, Saudi Arabia, Seychelles, Sierra Leone, Somalia, South Sudan, Tanzania, Uganda, United Arab Emirates, Western Sahara, Yemen, Zambia, and Zimbabwe: All disputes arising out of this Agreement shall be finally settled by the London Court of International Arbitration (LCIA) (Arbitration Body), under the LCIA Arbitration Rules (the Rules), in London, UK, with English as the official language, by three impartial arbitrators appointed in accordance with the Rules. Each party will nominate one arbitrator, who will jointly appoint an independent chairman within 30 days or else the chairman will be appointed by the Arbitration Body under the Rules. The arbitrators will have no authority to award injunctive relief or damages excluded by or exceeding limits in this Agreement. Nothing in this Agreement will prevent either party from resorting to judicial proceedings for (1) interim relief to prevent material prejudice or a breach of confidentiality provisions or intellectual property rights, or (2) determining the validity or ownership of any copyright, patent or trademark owned or asserted by a party or its Enterprise company, or (3) debt collection in amounts below USD 500,000.00.
+
+In Algeria, Benin, Burkina Faso, Cameroon, Central African Republic, Chad, Congo Republic, Democratic Republic of Congo, Equatorial Guinea, French Guiana, French Polynesia, Gabon, Guinea, Guinea-Bissau, Ivory Coast, Mali, Mauritania, Mauritius, Morocco, Niger, Senegal, Togo, and Tunisia: All disputes arising out of this Agreement shall be finally settled by the ICC International Court of Arbitration, in Paris (Arbitration Body), under its arbitration rules (the Rules), in Paris, France, with French as the official language, by three impartial arbitrators appointed in accordance with the Rules. Each party will nominate one arbitrator, who will jointly appoint an independent chairman within 30 days or else the chairman will be appointed by the Arbitration Body under the Rules. The arbitrators will have no authority to award injunctive relief or damages excluded by or exceeding limits in this Agreement. Nothing in this Agreement will prevent either party from resorting to judicial proceedings for (1) interim relief to prevent material prejudice or a breach of confidentiality provisions or intellectual property rights, or (2) determining the validity or ownership of any copyright, patent or trademark owned or asserted by a party or its Enterprise company, or (3) debt collection in amounts below USD 250,000.00.
+
+In South Africa, Namibia, Lesotho, and Swaziland: All disputes arising out of this Agreement shall be finally settled by the Arbitration Foundation of Southern Africa (AFSA) (Arbitration Body), under the Rules of the Arbitration of the AFSA (the Rules), in Johannesburg, South Africa, with English as the official language, by three impartial arbitrators appointed in accordance with the Rules. Each party will nominate one arbitrator, who will jointly appoint an independent chairman within 30 days or else the chairman will be appointed by the Arbitration Body under the Rules. The arbitrators will have no authority to award injunctive relief or damages excluded by or exceeding limits in this Agreement. Nothing in this Agreement will prevent either party from resorting to judicial proceedings for (1) interim relief to prevent material prejudice or a breach of confidentiality provisions or intellectual property rights, or (2) determining the validity or ownership of any copyright, patent or trademark owned or asserted by a party or its Enterprise company, or (3) debt collection in amounts below USD 250,000.00.
+
+In Andorra, Austria, Cyprus, France, Germany, Greece, Israel, Italy, Portugal, Spain, Switzerland, and Turkey: All disputes will be brought before and subject to the exclusive jurisdiction of the following court of competent jurisdiction:
+
+In Andorra: the Commercial Court of Paris.
+
+In Austria: the court of Vienna, Austria (Inner City).
+
+In Cyprus: the competent court of Nicosia.
+
+In France: Commercial Court of Paris.
+
+In Germany: the courts of Stuttgart.
+
+In Greece: the competent court of Athens.
+
+In Israel: the courts of Tel Aviv Jaffa.
+
+In Italy: the courts of Milan.
+
+In Portugal: the courts of Lisbon.
+
+In Spain: the courts of Madrid.
+
+In Switzerland: the commercial court of the canton of Zurich.
+
+In Turkey: the Istanbul Central (Caglayan) Courts and Execution Directorates of Istanbul, the Republic of Turkey.
+
+In Netherlands: The Parties waive their rights under Title 7.1 ('Koop') and clause 7:401 and 402 of the Dutch Civil Code, and their rights to invoke a full or partial dissolution ('gehele of partiele ontbinding') of this Agreement under section 6:265 of the Dutch Civil Code.
+
+Section 7. General
+
+In paragraph d, insert the following at the end of the paragraph:
+
+In Spain: IBM will comply with requests to access, update or delete contact information if submitted to the following address: IBM, c/ Santa Hortensia 26-28, 28002 Madrid, Departamento de Privacidad de Datos.
+
+In paragraph j, add to the end the paragraph:
+
+In Czech Republic: Pursuant to Section 1801 of Act No. 89/2012 Coll. (the "Civil Code"), Section 1799 and Section 1800 of the Civil Code as amended, do not apply to transactions under this Agreement. Licensee accepts the risk of a change of circumstances under Section 1765 of the Civil Code.
+
+In paragraph j:
+
+In Bulgaria, Croatia, Russia, Serbia, and Slovenia: delete the 2nd sentence that says: "Neither party will bring a legal action arising out of or related to the Agreement more than two years after the cause of action arose".
+
+In paragraph j, add to the end of the second sentence:
+
+In Lithuania: , except as provided by law
+
+In paragraph j, replace the second sentence with:
+
+In Poland: Neither party will bring a legal action arising out of or related to the Agreement more than three years after the cause of action arose, except for an action of non-payment which will be brought no more than 2 years after payment is due.
+
+In paragraph j, second sentence, replace the word "two" with:
+
+In Latvia and Ukraine: three
+
+In Slovakia: four
+
+In paragraph j, add to the end of the third sentence that says: "Neither party is responsible for failure to fulfill its non-monetary obligations due to causes beyond its control":
+
+In Russia: , including but not limited to earthquakes, floods, fires, acts of God, strikes (excluding strikes of the parties' employees), acts of war, military actions, embargoes, blockades, international or governmental sanctions, and acts of authorities of the applicable jurisdiction.
+
+In paragraph j, third sentence, modify the sentence: "Neither party is responsible for failure to fulfill its non-monetary obligations due to causes beyond its control" as follows:
+
+In Ukraine: Neither party is responsible for failure to fulfill its non-monetary obligations due to causes or regulatory changes beyond its control, including but not limited to import, export and economic sanctions requirements of the United States.
+
+Add the following at the end of the section as new paragraph l:
+
+In Hungary: By entering into this Agreement, Licensee confirms that Licensee was sufficiently informed of all the provisions of this Agreement and had the opportunity to negotiate those terms. The following provisions may significantly deviate from the provisions generally applied by Hungarian law and both parties accept those provisions by signing the Agreement: Program License; Warranties; Charges, Taxes, Payment, and Verification; Liability; Termination; Governing Laws and Geographic Scope; and General.
+
+In Czech Republic: Licensee expressly accepts the terms of this agreement which include the following important commercial terms: i) limitation and disclaimer of liability for defects (Warranties); ii) limitation of Licensee's entitlement to damages (Liability); iii) binding nature of export and import regulations (Governing Laws and Geographic Scope); iv) shorter limitation periods (General); v) exclusion of applicability of provisions on adhesion contracts (General); and vi) acceptance of the risk of a change of circumstances (General).
+
+In Romania: The Licensee expressly accepts, the following standard clauses that may be deemed 'unusual clauses' as per the provisions of article 1203 Romanian Civil Code: clauses 2, 4, 5, 8j. The Licensee hereby acknowledges that it was sufficiently informed of all the provisions of this Agreement, including the clauses mentioned above, it properly analyzed and understood such provisions and had the opportunity to negotiate the terms of each clause.
+
+i125-5543-06 (10-2021)

--- a/charts/ibm-watson-tts-embed-runtime/templates/NOTES.txt
+++ b/charts/ibm-watson-tts-embed-runtime/templates/NOTES.txt
@@ -1,0 +1,25 @@
+Thank you for installing {{ .Chart.Name }}.
+
+Your release is named {{ .Release.Name }}.
+
+To learn more about the release, try:
+
+  $ helm status {{ .Release.Name }}
+  $ helm get all {{ .Release.Name }}
+
+Example Usage:
+
+In one terminal, create a port-forward through the service:
+
+   $ kubectl port-forward svc/{{ include "ibm-watson-tts-embed-runtime.fullname" . }} 1443:443
+
+In another terminal, send a /synthesize request to generate speech and write out output.wav:
+
+   $ curl --url "https://localhost:1443/text-to-speech/api/v1/synthesize?voice=en-US_AllisonV3Voice" \
+      --insecure \
+      --header "Content-Type: application/json" \
+      --data '{"text":"Hello world"}' \
+      --header "Accept: audio/wav" \
+      --output output.wav
+
+Use an audio player to play the synthesized output.wav file.

--- a/charts/ibm-watson-tts-embed-runtime/templates/_helpers.yaml
+++ b/charts/ibm-watson-tts-embed-runtime/templates/_helpers.yaml
@@ -1,0 +1,11 @@
+{{- define "ibm-watson-tts-embed-runtime.fullname" -}}
+  {{- include "ibm-embed-helpers.fullname" . -}}
+{{- end }}
+
+{{- define "ibm-watson-tts-embed-runtime.labels" -}}
+  {{- include "ibm-embed-helpers.labels" (list . "runtime") -}}
+{{- end }}
+
+{{- define "ibm-watson-tts-embed-runtime.selectorLabels" -}}
+  {{- include "ibm-embed-helpers.selectorLabels" (list . "runtime") -}}
+{{- end }}

--- a/charts/ibm-watson-tts-embed-runtime/templates/configmap.yaml
+++ b/charts/ibm-watson-tts-embed-runtime/templates/configmap.yaml
@@ -1,0 +1,127 @@
+{{- $modelList := (list) -}}
+{{- range $model := .Values.models -}}
+  {{- if .enabled -}}
+    {{- $modelList = append $modelList $model.catalogName -}}
+  {{- end -}}
+{{- end -}}
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "ibm-watson-tts-embed-runtime.fullname" . }}
+  labels:
+    {{- include "ibm-watson-tts-embed-runtime.labels" . | nindent 4 }}
+data:
+  env_config.json: |
+    {
+      "allowDashboard": false,
+      "anonymizeLogs": false,
+      "baseModelsSURL": {
+        "service": "localPath",
+        "urlSuffix": "var/catalog.json"
+      },
+      "clusterGroups": {
+        "default": {
+          "service_type": "text-to-speech",
+          "component": "runtime",
+          "dns": "{{ include "ibm-watson-tts-embed-runtime.fullname" . }}",
+          "group": "default",
+          "models":
+            {{- $modelList | mustToPrettyJson | nindent 12 }}
+        }
+      },
+      "defaultTTSVoice": "{{ .Values.defaultModel}}",
+      "defaultVerbosity": "INFO",
+      "meteringEnabled": false,
+      "requireCookies": false,
+      "setCookies": false,
+      "serviceDependencies": {
+        "baseModelsStore": {
+          "type": "UrlService",
+          "healthCheckSuffix": "/",
+          "baseUrl": "http://127.0.0.1:3333/"
+        }
+      }
+    }
+
+  sessionPools.yaml: |
+    defaultPolicy: DefaultPolicy
+    sessionPoolPolicies:
+      PreWarmingPolicy:
+{{- range $modelName := $modelList -}}
+  {{- printf "- name: %s" $modelName | nindent 8 -}}
+{{- end }}
+
+  sessionPools.py: |
+    class PreWarmingPolicy:
+        sessionPool = {
+            'minWarmSessions': 1,
+            'maxUseCount': 1000
+        }
+
+    class NoPreWarmingPolicy:
+        sessionPool = {
+            'maxUseCount': 1000
+        }
+
+    class DefaultPolicy:
+        sessionPool = {}
+
+
+  resourceRequirements.py: |
+    class WTTSDnnResourceRequirement:
+      resourceRequirement = {
+        'marginalMem' : 250*2**20, # 130 MB
+        'marginalCpu' : 40
+      }
+
+  haproxy.cfg: |
+    global
+      ssl-default-bind-options no-sslv3
+      ssl-default-bind-ciphers ECDH+AESGCM:DH+AESGCM:ECDH+AES256:DH+AES256:ECDH+AES128:DH+AES:RSA+AESGCM:RSA+AES:!aNULL:!MD5:!DSS
+
+      ssl-default-server-options no-sslv3
+      ssl-default-server-ciphers ECDH+AESGCM:DH+AESGCM:ECDH+AES256:DH+AES256:ECDH+AES128:DH+AES:RSA+AESGCM:RSA+AES:!aNULL:!MD5:!DSS
+
+      tune.ssl.default-dh-param 2048
+      log  127.0.0.1:1514       local0  debug
+
+    defaults
+      mode http
+      log global
+      option httplog
+      option dontlognull
+
+      retries 0
+      timeout connect 5000
+      timeout client 100000
+      timeout server 100000
+      option http-server-close
+      option http-no-delay
+
+      # JSON error responses
+      errorfile 400 /etc/haproxy/errors/400_json.http
+      errorfile 403 /etc/haproxy/errors/403_json.http
+      errorfile 408 /etc/haproxy/errors/408_json.http
+      errorfile 500 /etc/haproxy/errors/500_json.http
+      errorfile 502 /etc/haproxy/errors/502_json.http
+      errorfile 503 /etc/haproxy/errors/503_json.http
+      errorfile 504 /etc/haproxy/errors/504_json.http
+
+      stats enable
+      stats uri /stats
+
+    frontend the-frontend
+      bind *:1443 ssl crt /tmp/haproxy.tls
+
+      http-request add-header Via %[req.ver]\ %fi
+      http-request add-header X-Forwarded-Proto http if { hdr_cnt(X-Forwarded-Proto) eq 0 }
+      capture request header X-Global-Transaction-Id len 32
+      default_backend the-backend
+
+    backend the-backend
+      server runtime 127.0.0.1:1080 check
+
+
+  prepareModels.sh: |-
+    {{ tpl (.Files.Get "files/prepareModels.sh") . | nindent 4 }}

--- a/charts/ibm-watson-tts-embed-runtime/templates/deployment.yaml
+++ b/charts/ibm-watson-tts-embed-runtime/templates/deployment.yaml
@@ -1,0 +1,216 @@
+{{- if not (eq .Values.license true) }}
+{{- fail "Product licenses must be read and accepted. Then set `license` to true" }}
+{{- end }}
+
+{{- /* Construct the list of model images to use in initContainers */}}
+{{- $modelsList := (include "ibm-embed-helpers.enabledModelImageConfigs" .) | fromYamlArray }}
+
+{{- /* Always include the model catalog upload */}}
+{{- $modelsList = concat (list .Values.images.catalog) $modelsList }}
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "ibm-watson-tts-embed-runtime.fullname" . }}
+  labels:
+    {{- include "ibm-watson-tts-embed-runtime.labels" . | nindent 4 }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "ibm-watson-tts-embed-runtime.selectorLabels" . | nindent 6 }}
+  progressDeadlineSeconds: 1800
+  template:
+    metadata:
+      labels:
+        {{- include "ibm-watson-tts-embed-runtime.labels" . | nindent 8 }}
+    spec:
+      imagePullSecrets:
+        {{- .Values.imagePullSecrets | toYaml | nindent 8 }}
+
+      {{- include "ibm-embed-helpers.podSecurityContext" . | nindent 6 -}}
+
+      initContainers:
+      {{- range $index, $model := $modelsList }}
+      - name: {{ $model.repository }}
+        image: {{ include "ibm-embed-helpers.imageReference" (list $ $model) }}
+        {{- include "ibm-embed-helpers.containerSecurityContext" . | nindent 8 -}}
+        env:
+        - name: ACCEPT_LICENSE
+          value: {{ $.Values.license | quote }}
+        resources:
+          {{- $.Values.resources.runtime | toYaml | nindent 10 }}
+
+        {{- if contains "generic-models" $model.repository }}
+        # use args to not override license entrypoint
+        args: ["cp", "catalog.json", "/opt/ibm/chuck.x86_64/var"]
+        volumeMounts:
+        - name: chuck-var
+          mountPath: /opt/ibm/chuck.x86_64/var
+        {{- else }}
+        # use args to not override license entrypoint
+        args:
+        - sh
+        - -c
+        - cp model/* /models/pool2
+        volumeMounts:
+        - name: chuck-models
+          mountPath: /models/pool2
+        {{- end }}
+      {{- end }}
+
+      - name: prepare-models
+        image: {{ include "ibm-embed-helpers.imageReference" (list . .Values.images.runtime) }}
+        {{- include "ibm-embed-helpers.containerSecurityContext" . | nindent 8 -}}
+        # use args to not override license entrypoint
+        args: ["bash", "/prepareModels.sh"]
+        env:
+        - name: ACCEPT_LICENSE
+          value: {{ $.Values.license | quote }}
+        resources:
+          {{- .Values.resources.runtime | toYaml | nindent 10 }}
+        volumeMounts:
+        - name: chuck-var
+          mountPath: /opt/ibm/chuck.x86_64/var
+        - name: chuck-logs
+          mountPath: /opt/ibm/chuck.x86_64/logs
+        - name: chuck-models
+          mountPath: /models/pool2
+        - name: config
+          subPath: prepareModels.sh
+          mountPath: "/prepareModels.sh"
+        - name: config
+          mountPath: /opt/ibm/chuck.x86_64/var/env_config.json
+          subPath: env_config.json
+        - name: tmp
+          mountPath: /tmp
+
+      containers:
+      - name: runtime
+        image: {{ include "ibm-embed-helpers.imageReference" (list . .Values.images.runtime) }}
+        {{- include "ibm-embed-helpers.containerSecurityContext" . | nindent 8 -}}
+        resources:
+          {{- .Values.resources.runtime | toYaml | nindent 10 }}
+        env:
+        - name: ACCEPT_LICENSE
+          value: {{ $.Values.license | quote }}
+        - name: KUBERNETES_RESOURCE_CPUS
+          valueFrom:
+            resourceFieldRef:
+              containerName: runtime
+              resource: requests.cpu
+        - name: KUBERNETES_RESOURCE_MEM
+          valueFrom:
+            resourceFieldRef:
+              containerName: runtime
+              resource: requests.memory
+        ports:
+        - containerPort: 1080
+        startupProbe:
+          tcpSocket:
+            port: 1080
+          periodSeconds: 30
+          failureThreshold: 12
+        readinessProbe:
+          httpGet:
+             port: 1080
+             path: /v1/miniHealthCheck
+          periodSeconds: 10
+          timeoutSeconds: 1
+        livenessProbe:
+          tcpSocket:
+            port: 1080
+          periodSeconds: 30
+        volumeMounts:
+        - name: chuck-var
+          mountPath: /opt/ibm/chuck.x86_64/var
+        - name: chuck-logs
+          mountPath: /opt/ibm/chuck.x86_64/logs
+        - name: config
+          subPath: env_config.json
+          mountPath: /opt/ibm/chuck.x86_64/var/env_config.json
+        - name: config
+          subPath: sessionPools.yaml
+          mountPath: /opt/ibm/chuck.x86_64/var/sessionPools.yaml
+        - name: config
+          subPath: sessionPools.py
+          mountPath: /opt/ibm/chuck.x86_64/var/sessionPools.py
+        - name: config
+          subPath: resourceRequirements.py
+          mountPath: /opt/ibm/chuck.x86_64/var/resourceRequirements.py
+        # ephemeral volume for scratch space
+        - name: tmp
+          mountPath: /tmp
+        lifecycle:
+          preStop:
+            exec:
+              command:
+              - /bin/sleep
+              - "15"
+
+      - name: haproxy
+        image: {{ include "ibm-embed-helpers.imageReference" (list . .Values.images.haproxy) }}
+        {{- include "ibm-embed-helpers.containerSecurityContext" . | nindent 8 -}}
+        # use args to not override license entrypoint
+        args:
+          - sh
+          - -c
+          # HAProxy needs a single file with the key and cert
+          #   write combined file to a read-write mount
+          - cat /etc/ssl/private/server/tls.crt /etc/ssl/private/server/tls.key > /tmp/haproxy.tls;
+            exec /runHaproxy.sh;
+        resources:
+          {{- .Values.resources.haproxy | toYaml | nindent 10 }}
+        env:
+        - name: ACCEPT_LICENSE
+          value: {{ .Values.license | quote }}
+        ports:
+        - containerPort: 1443
+        readinessProbe:
+          httpGet:
+            path: /v1
+            port: 1443
+            scheme: HTTPS
+          initialDelaySeconds: 10
+          periodSeconds: 10
+          timeoutSeconds: 1
+        livenessProbe:
+          tcpSocket:
+            port: 1443
+          initialDelaySeconds: 15
+          periodSeconds: 30
+        volumeMounts:
+        - mountPath: /etc/ssl/private/server
+          name: server-tls
+        - mountPath: /etc/haproxy/haproxy.cfg
+          name: config
+          subPath: haproxy.cfg
+        - name: tmp
+          mountPath: /tmp
+
+      volumes:
+        - name: chuck-var
+          emptyDir: {}
+        - name: chuck-models
+          emptyDir: {}
+        - name: chuck-cache
+          emptyDir: {}
+        - name: chuck-logs
+          emptyDir: {}
+        - name: config
+          configMap:
+            name: {{ include "ibm-watson-tts-embed-runtime.fullname" . }}
+        - name: tmp
+          emptyDir: {}
+        - name: server-tls
+          secret:
+            secretName: {{ include "ibm-watson-tts-embed-runtime.fullname" . }}-tls-server
+
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: "kubernetes.io/arch"
+                operator: In
+                values:
+                  - "amd64"

--- a/charts/ibm-watson-tts-embed-runtime/templates/service.yaml
+++ b/charts/ibm-watson-tts-embed-runtime/templates/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "ibm-watson-tts-embed-runtime.fullname" . }}
+  labels:
+    {{- include "ibm-watson-tts-embed-runtime.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.serviceType }}
+  selector:
+    {{- include "ibm-watson-tts-embed-runtime.selectorLabels" . | nindent 4 }}
+  ports:
+    - name: https
+      protocol: TCP
+      port: 443
+      targetPort: 1443

--- a/charts/ibm-watson-tts-embed-runtime/templates/tls.yaml
+++ b/charts/ibm-watson-tts-embed-runtime/templates/tls.yaml
@@ -1,0 +1,24 @@
+{{/*
+Generate a Certificate Authority Cert
+*/}}
+{{- $rootca := genCA "ibm-watson-tts-embed-runtime-ca" 3650 -}}
+
+{{/*
+Server Certificate
+*/}}
+{{- $altNames := list -}}
+{{- $runtimeService := include "ibm-watson-tts-embed-runtime.fullname" . -}}
+{{- $altNames := append $altNames "localhost" -}}
+{{- $altNames := append $altNames (printf "%s" $runtimeService) -}}
+{{- $altNames := append $altNames (printf "%s.%s" $runtimeService .Release.Namespace) -}}
+{{- $altNames := append $altNames (printf "%s.%s.svc" $runtimeService .Release.Namespace) -}}
+{{- $serverCert := include "ibm-embed-helpers.genCert" (list $rootca $altNames) | fromJson -}}
+
+apiVersion: v1
+kind: Secret
+type: kubernetes.io/tls
+metadata:
+  name: {{ include "ibm-watson-tts-embed-runtime.fullname" . }}-tls-server
+  labels:
+    {{- include "ibm-watson-tts-embed-runtime.labels" . | nindent 4 }}
+stringData: {{- include "ibm-embed-helpers.certStringdata" (list $rootca $serverCert) -}}

--- a/charts/ibm-watson-tts-embed-runtime/values.yaml
+++ b/charts/ibm-watson-tts-embed-runtime/values.yaml
@@ -1,0 +1,182 @@
+# By setting license to true you indicate that you have read and agree to the
+# license agreements:
+# https://www14.software.ibm.com/cgi-bin/weblap/lap.pl?li_formnum=L-DAJI-CHRHDK
+license: false
+
+containerRegistry: "cp.icr.io/cp/ai"
+serviceType: ClusterIP
+imagePullSecrets:
+  - name: ibm-entitlement-key
+
+nameOverride: ""
+fullnameOverride: ""
+
+images:
+  runtime:
+    repository: watson-tts-runtime
+    digest: sha256:ed0fe12195ab85056abf3bdbea98ea8feedfa371af63770906359e852bd85f47
+    tag: 1.0.0
+  haproxy:
+    repository: watson-tts-haproxy
+    digest: sha256:c71936b76e5385229916598e11a8cbece56b1354123b374e19e29512356b958f
+    tag: 1.0.0
+  catalog:
+    repository: watson-tts-generic-models
+    digest: sha256:86d6718f69093f76be861bfabdd95e8fe4b1aed39c23017346af8c66d1adf3b6
+    tag: 1.0.0
+
+# Configures the resources
+resources:
+  runtime:
+    requests:
+      cpu: 1
+      memory: 4Gi
+      ephemeral-storage: 4Gi
+    limits:
+      cpu: 4
+      memory: 4Gi
+      ephemeral-storage: 4Gi
+  haproxy:
+    requests:
+      cpu: 0.2
+      memory: 1Gi
+      ephemeral-storage: 64Mi
+    limits:
+      cpu: 1
+      memory: 1Gi
+      ephemeral-storage: 64Mi
+
+defaultModel: en-US_AllisonV3Voice
+models:
+  deDEBirgitV3Voice:
+    catalogName: de-DE_BirgitV3Voice
+    repository: watson-tts-de-de-birgitv3voice
+    digest: sha256:28dbde73c51f7fc0c409574d488df7454a6ea0581fed94612cffe8937ab2f16f
+    tag: 1.0.0
+    enabled: false
+  deDEDieterV3Voice:
+    catalogName: de-DE_DieterV3Voice
+    repository: watson-tts-de-de-dieterv3voice
+    digest: sha256:e1ab34be2ef38472f8740bbdf5cf0138ed8f3e967216fb65fb519d5dddd5da07
+    tag: 1.0.0
+    enabled: false
+  deDEErikaV3Voice:
+    catalogName: de-DE_ErikaV3Voice
+    repository: watson-tts-de-de-erikav3voice
+    digest: sha256:8cab2c54ade8c5f8d655465dfe40e2447550e83956ca6d7d0baa29ed17e979dd
+    tag: 1.0.0
+    enabled: false
+  enGBCharlotteV3Voice:
+    catalogName: en-GB_CharlotteV3Voice
+    repository: watson-tts-en-gb-charlottev3voice
+    digest: sha256:72f0065c388c707148695f339718c92e5d1b8c4f29afad407268071d4f3190ed
+    tag: 1.0.0
+    enabled: false
+  enGBJamesV3Voice:
+    catalogName: en-GB_JamesV3Voice
+    repository: watson-tts-en-gb-jamesv3voice
+    digest: sha256:fd084e50305dcd6db4ba01374e12b6503f94db28f36a114e2d00786a1c20b9a0
+    tag: 1.0.0
+    enabled: false
+  enGBKateV3Voice:
+    catalogName: en-GB_KateV3Voice
+    repository: watson-tts-en-gb-katev3voice
+    digest: sha256:19eefe60cd5d1cebc37bbe8d86b2f6b8a4ddf45aa2635b7ef793540de9aa308a
+    tag: 1.0.0
+    enabled: false
+  enUSAllisonV3Voice:
+    catalogName: en-US_AllisonV3Voice
+    repository: watson-tts-en-us-allisonv3voice
+    digest: sha256:ec239ae990a7da2b6f9637a6147656aeae57fdf29dde70dde51d531a7d391a0f
+    tag: 1.0.0
+    enabled: true
+  enUSEmilyV3Voice:
+    catalogName: en-US_EmilyV3Voice
+    repository: watson-tts-en-us-emilyv3voice
+    digest: sha256:3595ecc0561f0228d4141edfdd62febdee8a68a7b62b4dad5d055da7f59f95d2
+    tag: 1.0.0
+    enabled: false
+  enUSKevinV3Voice:
+    catalogName: en-US_KevinV3Voice
+    repository: watson-tts-en-us-kevinv3voice
+    digest: sha256:c7b93117fd3716a6b73becb0fa80d2920d6aa440b2be4ff9f36efad16b3f6204
+    tag: 1.0.0
+    enabled: false
+  enUSLisaV3Voice:
+    catalogName: en-US_LisaV3Voice
+    repository: watson-tts-en-us-lisav3voice
+    digest: sha256:ba615a039de4cd0c6e13c5ff856992daa511e2f72352af0f1889ff89b53c0d14
+    tag: 1.0.0
+    enabled: false
+  enUSMichaelV3Voice:
+    catalogName: en-US_MichaelV3Voice
+    repository: watson-tts-en-us-michaelv3voice
+    digest: sha256:8f1494f4da27e1f096483b957744caa18b571e85c8c8eb278be7e244e7c0c53a
+    tag: 1.0.0
+    enabled: true
+  enUSOliviaV3Voice:
+    catalogName: en-US_OliviaV3Voice
+    repository: watson-tts-en-us-oliviav3voice
+    digest: sha256:49dcfc9c3206cc1d58551b57f96edbfed94307e16e5a7379b7b781c08387c965
+    tag: 1.0.0
+    enabled: false
+  esESEnriqueV3Voice:
+    catalogName: es-ES_EnriqueV3Voice
+    repository: watson-tts-es-es-enriquev3voice
+    digest: sha256:785286b8fa6b029edc4778c579954454d551e3481ae7644136ab211e1d8dfccd
+    tag: 1.0.0
+    enabled: false
+  esESLauraV3Voice:
+    catalogName: es-ES_LauraV3Voice
+    repository: watson-tts-es-es-laurav3voice
+    digest: sha256:72487cc6e23ce441d531a1646e77afba904da54dca57a933ffb366e799c3af12
+    tag: 1.0.0
+    enabled: false
+  esLASofiaV3Voice:
+    catalogName: es-LA_SofiaV3Voice
+    repository: watson-tts-es-la-sofiav3voice
+    digest: sha256:9a3050476d888335fd81c8ec591fe2e3141227719c0e1b5fd30eec2afec1ee7f
+    tag: 1.0.0
+    enabled: false
+  esUSSofiaV3Voice:
+    catalogName: es-US_SofiaV3Voice
+    repository: watson-tts-es-us-sofiav3voice
+    digest: sha256:31316a6396cc2126176e7bcf09bda8515f1dbf003ce81058e8454a2e85e66afe
+    tag: 1.0.0
+    enabled: false
+  frCALouiseV3Voice:
+    catalogName: fr-CA_LouiseV3Voice
+    repository: watson-tts-fr-ca-louisev3voice
+    digest: sha256:e2c50f6a632de6c4db26edd6a9b8f841bae6bc4296b2a54f3b86ef59cfb10ecb
+    tag: 1.0.0
+    enabled: false
+  frFRNicolasV3Voice:
+    catalogName: fr-FR_NicolasV3Voice
+    repository: watson-tts-fr-fr-nicolasv3voice
+    digest: sha256:84b019ac979364f4ebb0a1f5a88dffc91acc14dd07545aab17013e9c21062dbf
+    tag: 1.0.0
+    enabled: false
+  frFRReneeV3Voice:
+    catalogName: fr-FR_ReneeV3Voice
+    repository: watson-tts-fr-fr-reneev3voice
+    digest: sha256:b4aa393c0638eceedab6af784b9d8a295700895d95b613b02c04297f4d039d53
+    tag: 1.0.0
+    enabled: false
+  itITFrancescaV3Voice:
+    catalogName: it-IT_FrancescaV3Voice
+    repository: watson-tts-it-it-francescav3voice
+    digest: sha256:a4f20cee15c1d6cff1e5f06f6038d5f0a37bbad3fd5277149ca4e3b7630c667d
+    tag: 1.0.0
+    enabled: false
+  jaJPEmiV3Voice:
+    catalogName: ja-JP_EmiV3Voice
+    repository: watson-tts-ja-jp-emiv3voice
+    digest: sha256:b8b320a47db94b80e800ce39aea8f5a041c1a7861144b706875b08f5a47e2b0e
+    tag: 1.0.0
+    enabled: false
+  ptBRIsabelaV3Voice:
+    catalogName: pt-BR_IsabelaV3Voice
+    repository: watson-tts-pt-br-isabelav3voice
+    digest: sha256:5e73c30d6f29c42f80bdac09c3dfcbeac88a629bc11f2a04b12137afafafbecd
+    tag: 1.0.0
+    enabled: false


### PR DESCRIPTION
The initial charts that show how to deploy and configure the Speech to Text and Text to Speech runtimes of the Watson Libraries for Embed products.