### PR TITLE
Update charts for stt and tts 1.3.0 embed release

### DIFF
--- a/charts/ibm-watson-stt-embed-runtime/values.yaml
+++ b/charts/ibm-watson-stt-embed-runtime/values.yaml
@@ -22,16 +22,16 @@ serviceType: ClusterIP
 images:
   runtime:
     repository: watson-stt-runtime
-    digest: sha256:18849c5d3fdff4fb2337531b0bee80c1780982bdf1c9dc560a8c46f293425c41
-    tag: 1.2.0
+    digest: sha256:f494e3c278e06797811651e209a5726bc6b4b5f08bccc080e74a7007c1cedc59
+    tag: 1.3.0
   haproxy:
     repository: watson-stt-haproxy
-    digest: sha256:05316e44308534a863ee40822eefa924b0344650e20c24dd8d50c1acc9d542ea
-    tag: 1.2.0
+    digest: sha256:9e03f2ad29cd713631c400029442a7eb2e7b319fb41a35714d288b874ee9da8e
+    tag: 1.3.0
   catalog:
     repository: watson-stt-generic-models
-    digest: sha256:34ad91e5778a9d37fd6fe828ea1957fa5b9352a5510992083260f37c6add5f3f
-    tag: 1.2.0
+    digest: sha256:a238e0401e560b988927922e0bda7a04c52e00c6da6ae89c255364d5d9810f99
+    tag: 1.3.0
 
 # resources sets per-container resource allocations
 resources:
@@ -62,156 +62,156 @@ models:
   arMSTelephony:
     catalogName: ar-MS_Telephony
     repository: watson-stt-ar-ms-telephony
-    digest: sha256:3af072912c809408474a02350aa549f711e45542d93297ff611c7830c522146a
-    tag: 1.2.0
+    digest: sha256:1a45accd923f37b1c79058af10d236c9ddbc03f0f03b552f2cbbc98c9346a0d6
+    tag: 1.3.0
     enabled: false
   csCZTelephony:
     catalogName: cs-CZ_Telephony
     repository: watson-stt-cs-cz-telephony
-    digest: sha256:6ac1c6b8465efb8a6050d0ed8b60e1380bb4d61f6bb8f2676f952da7585d34fc
-    tag: 1.2.0
+    digest: sha256:3f19a76ae49611e4a32c866912eb6fa23a72b7d17a220519e85356bba39dbeed
+    tag: 1.3.0
     enabled: false
   deDEMultimedia:
     catalogName: de-DE_Multimedia
     repository: watson-stt-de-de-multimedia
-    digest: sha256:674ebee8cc914179bcbe0d01f301f8e5fa93b9177dbca7e696663e1752e4331d
-    tag: 1.2.0
+    digest: sha256:432f4346fa56e28fbd33ea0d251d45f73d9f882005e234345cdc77ea1ce50e94
+    tag: 1.3.0
     enabled: false
   deDETelephony:
     catalogName: de-DE_Telephony
     repository: watson-stt-de-de-telephony
-    digest: sha256:bce0db6625713249a5f493b45e644a85f34055e505ccb8086171496eb251dd0e
-    tag: 1.2.0
+    digest: sha256:5dfda135e1dbe3424bc39df491cc2fc2684264df50bab0964ae884014ed6b521
+    tag: 1.3.0
     enabled: false
   enINTelephony:
     catalogName: en-IN_Telephony
     repository: watson-stt-en-in-telephony
-    digest: sha256:3e3c34eec2cc446e4c4b1ad760040a6fe9393da13070bb8e8cf9b661daf42e26
-    tag: 1.2.0
+    digest: sha256:45313e2ac5c4b7083aff44c4b0ac86f642062e8a51769e77e9773b82eea0f3a1
+    tag: 1.3.0
     enabled: false
   enUSMultimedia:
     catalogName: en-US_Multimedia
     repository: watson-stt-en-us-multimedia
-    digest: sha256:39498b7cc15c57929729bc05a71bab090deb7d413d0a908089dba584ca7fe728
-    tag: 1.2.0
+    digest: sha256:65b799afc8973832a18c84c5b52dd8e5a083d61395cb1f7ed4b67b8b533cd003
+    tag: 1.3.0
     enabled: true
   enUSTelephony:
     catalogName: en-US_Telephony
     repository: watson-stt-en-us-telephony
-    digest: sha256:c0c2bee6c2649241a49460784cd38b4922c22111e17743dda7459ed28e9b3b1f
-    tag: 1.2.0
+    digest: sha256:6038e4a3a90b3f8046b9c439993e5f3f5c98863587ec7655bcc3e65db4cf03f7
+    tag: 1.3.0
     enabled: true
   enWWMedicalTelephony:
     catalogName: en-WW_Medical_Telephony
     repository: watson-stt-en-ww-medical-telephony
-    digest: sha256:d3bf833c4462b49bdf43605557fa7b90ab23f2f270ca8a2202fbbd2e878c0369
-    tag: 1.2.0
+    digest: sha256:50455e5e72a9d46234437182986c8ed12cbdc6624db0f11c9b6576a20d5f44b6
+    tag: 1.3.0
     enabled: false
   esESMultimedia:
     catalogName: es-ES_Multimedia
     repository: watson-stt-es-es-multimedia
-    digest: sha256:2ec63de2c5a545362b5de2be86a14a71e93ac47d2d797f88f75fe0849ca89309
-    tag: 1.2.0
+    digest: sha256:c031497571fc75b705589a88b1631ae4b46f4191eba88e3d6ebeb86fcf524955
+    tag: 1.3.0
     enabled: false
   esESTelephony:
     catalogName: es-ES_Telephony
     repository: watson-stt-es-es-telephony
-    digest: sha256:0a7b186dcd7d405c3d5d73476c9cb3265f8977d0cfed916cb7ac2a193faf4420
-    tag: 1.2.0
+    digest: sha256:758baa14fdd9d77e9fbbc45dcba904ecea543517385b399d0dfb8aa111fc6505
+    tag: 1.3.0
     enabled: false
   esLATelephony:
     catalogName: es-LA_Telephony
     repository: watson-stt-es-la-telephony
-    digest: sha256:167127de1da60eda1faa4cf48885697967114ac1910dd00edb9cc2c13daaf17e
-    tag: 1.2.0
+    digest: sha256:42bdeb94dfef50ce61493b8a13cc01a3558e91c02ec0e21c96a976441cbf47b7
+    tag: 1.3.0
     enabled: false
   frCAMultimedia:
     catalogName: fr-CA_Multimedia
     repository: watson-stt-fr-ca-multimedia
-    digest: sha256:be2c2736cc3e77041b16de3937056d05274f35931ea03a14697550d5ac88816b
-    tag: 1.2.0
+    digest: sha256:d6a2f6e06a3c9af111cd3bc98ebc439ccc38184ed0088d3af0627a76295011e2
+    tag: 1.3.0
     enabled: false
   frCATelephony:
     catalogName: fr-CA_Telephony
     repository: watson-stt-fr-ca-telephony
-    digest: sha256:33d7b7bfc9cdf7fba82e9b399c4b74c2e01765fbc10acf017d9f2264e732f5a3
-    tag: 1.2.0
+    digest: sha256:fe052ed43dd4231eae902ddc6f28a993927c4cdd0da0d3481149ba26160a451b
+    tag: 1.3.0
     enabled: false
   frFRMultimedia:
     catalogName: fr-FR_Multimedia
     repository: watson-stt-fr-fr-multimedia
-    digest: sha256:15ef1922d4ea43fc62f872a41290deeae5329f3e33a48318455818f178e43605
-    tag: 1.2.0
+    digest: sha256:9d4e7222f6a54a1f5ba7b4d3aaeff617d32e773464de1a752867e19d3949ad68
+    tag: 1.3.0
     enabled: false
   frFRTelephony:
     catalogName: fr-FR_Telephony
     repository: watson-stt-fr-fr-telephony
-    digest: sha256:61528faa2b74b1fe7f1beaf75dfb4c91ff21278d86c17122ba2b115e196db1c6
-    tag: 1.2.0
+    digest: sha256:ec49ad4580ff7e13b5ecf6f4e767e43c37021d3e2c1078490b8dae513d5ae418
+    tag: 1.3.0
     enabled: false
   hiINTelephony:
     catalogName: hi-IN_Telephony
     repository: watson-stt-hi-in-telephony
-    digest: sha256:ee210eb216a278c956acbe1599487d3570e22e8f4aa2032b2cd07c638b6b972f
-    tag: 1.2.0
+    digest: sha256:d7389d350830a95214bef1d11312423293f3633ffbb6709b8b0432830bb49f30
+    tag: 1.3.0
     enabled: false
   itITTelephony:
     catalogName: it-IT_Telephony
     repository: watson-stt-it-it-telephony
-    digest: sha256:108d4859137e084a3a00b6d1af197fe51b93fdadb6de21e8770602e100b98241
-    tag: 1.2.0
+    digest: sha256:c4f138dcf731348153f421ecea899222ff5d2454a6169ce51c3a988e4581ad1d
+    tag: 1.3.0
     enabled: false
   jaJPMultimedia:
     catalogName: ja-JP_Multimedia
     repository: watson-stt-ja-jp-multimedia
-    digest: sha256:d937b82cccb5b373da614c84316764a565c0eb9ce9fa99926a6536ad3f53d09d
-    tag: 1.2.0
+    digest: sha256:c9d858af2ac8106c321ed298e902e6560fb39685847a7341819bea3a41520b3a
+    tag: 1.3.0
     enabled: false
   koKRMultimedia:
     catalogName: ko-KR_Multimedia
     repository: watson-stt-ko-kr-multimedia
-    digest: sha256:45b22b81f9b39db805b8c14159bdd5459b416f460338798a95e6c892f778e6cd
-    tag: 1.2.0
+    digest: sha256:5dedded6c78f01bb82e4a3392d210c03510db9b0688299bf4fdccbe9e1b51889
+    tag: 1.3.0
     enabled: false
   koKRTelephony:
     catalogName: ko-KR_Telephony
     repository: watson-stt-ko-kr-telephony
-    digest: sha256:b4db741a5c7b8e92e7638cb3ede27eae556f3d3a8d99391a3bbf3be31050fc78
-    tag: 1.2.0
+    digest: sha256:07a04872edb770e4fc9dc48829d579a7c90e6489a87eded7186dd0d43c48060d
+    tag: 1.3.0
     enabled: false
   nlBETelephony:
     catalogName: nl-BE_Telephony
     repository: watson-stt-nl-be-telephony
-    digest: sha256:1a237b54c09d87c5b6f42e33c1718f63ca1c4ea200f60dbbbe065961cfc2ec95
-    tag: 1.2.0
+    digest: sha256:80d5343a60492bbb95ed1594a67bddc1dd6a35f6de0080f444e38723ceed9071
+    tag: 1.3.0
     enabled: false
   nlNLMultimedia:
     catalogName: nl-NL_Multimedia
     repository: watson-stt-nl-nl-multimedia
-    digest: sha256:164d966fc61be3aa6da5c398591ec0434d9fef6761ca40de9644f842c48660ca
-    tag: 1.2.0
+    digest: sha256:03b65c11fb15d056250c63ff8e1b67691e4e633ee88e40ed0c2e7c5b4700b4c9
+    tag: 1.3.0
     enabled: false
   nlNLTelephony:
     catalogName: nl-NL_Telephony
     repository: watson-stt-nl-nl-telephony
-    digest: sha256:2bb3b9cd49aae6eff06cb41dddd266fd22e9135c21f64de6e28d57dae248f72d
-    tag: 1.2.0
+    digest: sha256:660bfdf1a6eb681da26184eaf720d3baa9bc36329091c8a9af6f05c926237a48
+    tag: 1.3.0
     enabled: false
   ptBRMultimedia:
     catalogName: pt-BR_Multimedia
     repository: watson-stt-pt-br-multimedia
-    digest: sha256:a45798497417e4e81480a90cd640f004506998fa5d600a79ffa6cccd2bedcb5b
-    tag: 1.2.0
+    digest: sha256:e753e11efcae76fa0388d3b010850aedd0398d8e27fb7204e14d66be0d0f39e6
+    tag: 1.3.0
     enabled: false
   ptBRTelephony:
     catalogName: pt-BR_Telephony
     repository: watson-stt-pt-br-telephony
-    digest: sha256:25aa19014c47abc87c53b5fe85c1cab12b269b9a9e824c463b401e3f250f2fed
-    tag: 1.2.0
+    digest: sha256:b372a2f235509c89b525f1235c54a47fc6ba8b3a6718934535644fd8f4498867
+    tag: 1.3.0
     enabled: false
   zhCNTelephony:
     catalogName: zh-CN_Telephony
     repository: watson-stt-zh-cn-telephony
-    digest: sha256:a57a6b2b2b1c79529972fbffb01135b24d34796ebdb07323c367d9d553b0b7d0
-    tag: 1.2.0
+    digest: sha256:8f385685c7de97044df7252c206145e59a31d2dd929d9debb95143212a4c0f84
+    tag: 1.3.0
     enabled: false

--- a/charts/ibm-watson-stt-embed/templates/tests/job.yaml
+++ b/charts/ibm-watson-stt-embed/templates/tests/job.yaml
@@ -15,6 +15,9 @@ spec:
       labels:
         {{- include "ibm-watson-stt-embed.tests.labels" . | nindent 8 }}
     spec:
+      {{- include "ibm-embed-helpers.podSecurityContext" . | nindent 6 -}}
+      imagePullSecrets:
+        {{- .Values.imagePullSecrets | toYaml | nindent 8 }}
       restartPolicy: Never
       containers:
         - name: healthchecks

--- a/charts/ibm-watson-stt-embed/values.yaml
+++ b/charts/ibm-watson-stt-embed/values.yaml
@@ -89,186 +89,186 @@ resources:
 images:
   utils:
     repository: watson-stt-utils
-    digest: sha256:680676281dc45b12f0d70810f9634b7b433e2034fce477289aab92198e33870b
-    tag: 1.2.0
+    digest: sha256:d598cdebe2f6e80e906c2a7c1464ac7455dbaccf7f149faf2a387ffef28639e5
+    tag: 1.3.0
   runtime:
     repository: watson-stt-runtime
-    digest: sha256:18849c5d3fdff4fb2337531b0bee80c1780982bdf1c9dc560a8c46f293425c41
-    tag: 1.2.0
+    digest: sha256:f494e3c278e06797811651e209a5726bc6b4b5f08bccc080e74a7007c1cedc59
+    tag: 1.3.0
   haproxy:
     repository: watson-stt-haproxy
-    digest: sha256:05316e44308534a863ee40822eefa924b0344650e20c24dd8d50c1acc9d542ea
-    tag: 1.2.0
+    digest: sha256:9e03f2ad29cd713631c400029442a7eb2e7b319fb41a35714d288b874ee9da8e
+    tag: 1.3.0
   customization:
     repository: watson-stt-customization
-    digest: sha256:7a8d9dfb4ad4ec4ff2979f1f4113864e44df27585ee6d97e69d3bd99cf503c66
-    tag: 1.2.0
+    digest: sha256:375c96bbf548bb76552e25e6e3b16a8001beb1b324d730746413dc39884e67aa
+    tag: 1.3.0
   catalog:
     repository: watson-stt-generic-models
-    digest: sha256:34ad91e5778a9d37fd6fe828ea1957fa5b9352a5510992083260f37c6add5f3f
-    tag: 1.2.0
+    digest: sha256:a238e0401e560b988927922e0bda7a04c52e00c6da6ae89c255364d5d9810f99
+    tag: 1.3.0
 
 
 # defaultModel will be used if no model is included in the /recognize request
 defaultModel: en-US_Multimedia
 # modelVersion sets the path within model storage where the catalog will be uploaded
-modelVersion: "1.1.0"
+modelVersion: "1.3.0"
 # models has configuration for model container images and model enablement
 # To pull by tag, set digest to the empty string
 models:
   arMSTelephony:
     catalogName: ar-MS_Telephony
     repository: watson-stt-ar-ms-telephony
-    digest: sha256:3af072912c809408474a02350aa549f711e45542d93297ff611c7830c522146a
-    tag: 1.2.0
+    digest: sha256:1a45accd923f37b1c79058af10d236c9ddbc03f0f03b552f2cbbc98c9346a0d6
+    tag: 1.3.0
     enabled: false
   csCZTelephony:
     catalogName: cs-CZ_Telephony
     repository: watson-stt-cs-cz-telephony
-    digest: sha256:6ac1c6b8465efb8a6050d0ed8b60e1380bb4d61f6bb8f2676f952da7585d34fc
-    tag: 1.2.0
+    digest: sha256:3f19a76ae49611e4a32c866912eb6fa23a72b7d17a220519e85356bba39dbeed
+    tag: 1.3.0
     enabled: false
   deDEMultimedia:
     catalogName: de-DE_Multimedia
     repository: watson-stt-de-de-multimedia
-    digest: sha256:674ebee8cc914179bcbe0d01f301f8e5fa93b9177dbca7e696663e1752e4331d
-    tag: 1.2.0
+    digest: sha256:432f4346fa56e28fbd33ea0d251d45f73d9f882005e234345cdc77ea1ce50e94
+    tag: 1.3.0
     enabled: false
   deDETelephony:
     catalogName: de-DE_Telephony
     repository: watson-stt-de-de-telephony
-    digest: sha256:bce0db6625713249a5f493b45e644a85f34055e505ccb8086171496eb251dd0e
-    tag: 1.2.0
+    digest: sha256:5dfda135e1dbe3424bc39df491cc2fc2684264df50bab0964ae884014ed6b521
+    tag: 1.3.0
     enabled: false
   enINTelephony:
     catalogName: en-IN_Telephony
     repository: watson-stt-en-in-telephony
-    digest: sha256:3e3c34eec2cc446e4c4b1ad760040a6fe9393da13070bb8e8cf9b661daf42e26
-    tag: 1.2.0
+    digest: sha256:45313e2ac5c4b7083aff44c4b0ac86f642062e8a51769e77e9773b82eea0f3a1
+    tag: 1.3.0
     enabled: false
   enUSMultimedia:
     catalogName: en-US_Multimedia
     repository: watson-stt-en-us-multimedia
-    digest: sha256:39498b7cc15c57929729bc05a71bab090deb7d413d0a908089dba584ca7fe728
-    tag: 1.2.0
+    digest: sha256:65b799afc8973832a18c84c5b52dd8e5a083d61395cb1f7ed4b67b8b533cd003
+    tag: 1.3.0
     enabled: true
   enUSTelephony:
     catalogName: en-US_Telephony
     repository: watson-stt-en-us-telephony
-    digest: sha256:c0c2bee6c2649241a49460784cd38b4922c22111e17743dda7459ed28e9b3b1f
-    tag: 1.2.0
+    digest: sha256:6038e4a3a90b3f8046b9c439993e5f3f5c98863587ec7655bcc3e65db4cf03f7
+    tag: 1.3.0
     enabled: true
   enWWMedicalTelephony:
     catalogName: en-WW_Medical_Telephony
     repository: watson-stt-en-ww-medical-telephony
-    digest: sha256:d3bf833c4462b49bdf43605557fa7b90ab23f2f270ca8a2202fbbd2e878c0369
-    tag: 1.2.0
+    digest: sha256:50455e5e72a9d46234437182986c8ed12cbdc6624db0f11c9b6576a20d5f44b6
+    tag: 1.3.0
     enabled: false
   esESMultimedia:
     catalogName: es-ES_Multimedia
     repository: watson-stt-es-es-multimedia
-    digest: sha256:2ec63de2c5a545362b5de2be86a14a71e93ac47d2d797f88f75fe0849ca89309
-    tag: 1.2.0
+    digest: sha256:c031497571fc75b705589a88b1631ae4b46f4191eba88e3d6ebeb86fcf524955
+    tag: 1.3.0
     enabled: false
   esESTelephony:
     catalogName: es-ES_Telephony
     repository: watson-stt-es-es-telephony
-    digest: sha256:0a7b186dcd7d405c3d5d73476c9cb3265f8977d0cfed916cb7ac2a193faf4420
-    tag: 1.2.0
+    digest: sha256:758baa14fdd9d77e9fbbc45dcba904ecea543517385b399d0dfb8aa111fc6505
+    tag: 1.3.0
     enabled: false
   esLATelephony:
     catalogName: es-LA_Telephony
     repository: watson-stt-es-la-telephony
-    digest: sha256:167127de1da60eda1faa4cf48885697967114ac1910dd00edb9cc2c13daaf17e
-    tag: 1.2.0
+    digest: sha256:42bdeb94dfef50ce61493b8a13cc01a3558e91c02ec0e21c96a976441cbf47b7
+    tag: 1.3.0
     enabled: false
   frCAMultimedia:
     catalogName: fr-CA_Multimedia
     repository: watson-stt-fr-ca-multimedia
-    digest: sha256:be2c2736cc3e77041b16de3937056d05274f35931ea03a14697550d5ac88816b
-    tag: 1.2.0
+    digest: sha256:d6a2f6e06a3c9af111cd3bc98ebc439ccc38184ed0088d3af0627a76295011e2
+    tag: 1.3.0
     enabled: false
   frCATelephony:
     catalogName: fr-CA_Telephony
     repository: watson-stt-fr-ca-telephony
-    digest: sha256:33d7b7bfc9cdf7fba82e9b399c4b74c2e01765fbc10acf017d9f2264e732f5a3
-    tag: 1.2.0
+    digest: sha256:fe052ed43dd4231eae902ddc6f28a993927c4cdd0da0d3481149ba26160a451b
+    tag: 1.3.0
     enabled: false
   frFRMultimedia:
     catalogName: fr-FR_Multimedia
     repository: watson-stt-fr-fr-multimedia
-    digest: sha256:15ef1922d4ea43fc62f872a41290deeae5329f3e33a48318455818f178e43605
-    tag: 1.2.0
+    digest: sha256:9d4e7222f6a54a1f5ba7b4d3aaeff617d32e773464de1a752867e19d3949ad68
+    tag: 1.3.0
     enabled: false
   frFRTelephony:
     catalogName: fr-FR_Telephony
     repository: watson-stt-fr-fr-telephony
-    digest: sha256:61528faa2b74b1fe7f1beaf75dfb4c91ff21278d86c17122ba2b115e196db1c6
-    tag: 1.2.0
+    digest: sha256:ec49ad4580ff7e13b5ecf6f4e767e43c37021d3e2c1078490b8dae513d5ae418
+    tag: 1.3.0
     enabled: false
   hiINTelephony:
     catalogName: hi-IN_Telephony
     repository: watson-stt-hi-in-telephony
-    digest: sha256:ee210eb216a278c956acbe1599487d3570e22e8f4aa2032b2cd07c638b6b972f
-    tag: 1.2.0
+    digest: sha256:d7389d350830a95214bef1d11312423293f3633ffbb6709b8b0432830bb49f30
+    tag: 1.3.0
     enabled: false
   itITTelephony:
     catalogName: it-IT_Telephony
     repository: watson-stt-it-it-telephony
-    digest: sha256:108d4859137e084a3a00b6d1af197fe51b93fdadb6de21e8770602e100b98241
-    tag: 1.2.0
+    digest: sha256:c4f138dcf731348153f421ecea899222ff5d2454a6169ce51c3a988e4581ad1d
+    tag: 1.3.0
     enabled: false
   jaJPMultimedia:
     catalogName: ja-JP_Multimedia
     repository: watson-stt-ja-jp-multimedia
-    digest: sha256:d937b82cccb5b373da614c84316764a565c0eb9ce9fa99926a6536ad3f53d09d
-    tag: 1.2.0
+    digest: sha256:c9d858af2ac8106c321ed298e902e6560fb39685847a7341819bea3a41520b3a
+    tag: 1.3.0
     enabled: false
   koKRMultimedia:
     catalogName: ko-KR_Multimedia
     repository: watson-stt-ko-kr-multimedia
-    digest: sha256:45b22b81f9b39db805b8c14159bdd5459b416f460338798a95e6c892f778e6cd
-    tag: 1.2.0
+    digest: sha256:5dedded6c78f01bb82e4a3392d210c03510db9b0688299bf4fdccbe9e1b51889
+    tag: 1.3.0
     enabled: false
   koKRTelephony:
     catalogName: ko-KR_Telephony
     repository: watson-stt-ko-kr-telephony
-    digest: sha256:b4db741a5c7b8e92e7638cb3ede27eae556f3d3a8d99391a3bbf3be31050fc78
-    tag: 1.2.0
+    digest: sha256:07a04872edb770e4fc9dc48829d579a7c90e6489a87eded7186dd0d43c48060d
+    tag: 1.3.0
     enabled: false
   nlBETelephony:
     catalogName: nl-BE_Telephony
     repository: watson-stt-nl-be-telephony
-    digest: sha256:1a237b54c09d87c5b6f42e33c1718f63ca1c4ea200f60dbbbe065961cfc2ec95
-    tag: 1.2.0
+    digest: sha256:80d5343a60492bbb95ed1594a67bddc1dd6a35f6de0080f444e38723ceed9071
+    tag: 1.3.0
     enabled: false
   nlNLMultimedia:
     catalogName: nl-NL_Multimedia
     repository: watson-stt-nl-nl-multimedia
-    digest: sha256:164d966fc61be3aa6da5c398591ec0434d9fef6761ca40de9644f842c48660ca
-    tag: 1.2.0
+    digest: sha256:03b65c11fb15d056250c63ff8e1b67691e4e633ee88e40ed0c2e7c5b4700b4c9
+    tag: 1.3.0
     enabled: false
   nlNLTelephony:
     catalogName: nl-NL_Telephony
     repository: watson-stt-nl-nl-telephony
-    digest: sha256:2bb3b9cd49aae6eff06cb41dddd266fd22e9135c21f64de6e28d57dae248f72d
-    tag: 1.2.0
+    digest: sha256:660bfdf1a6eb681da26184eaf720d3baa9bc36329091c8a9af6f05c926237a48
+    tag: 1.3.0
     enabled: false
   ptBRMultimedia:
     catalogName: pt-BR_Multimedia
     repository: watson-stt-pt-br-multimedia
-    digest: sha256:a45798497417e4e81480a90cd640f004506998fa5d600a79ffa6cccd2bedcb5b
-    tag: 1.2.0
+    digest: sha256:e753e11efcae76fa0388d3b010850aedd0398d8e27fb7204e14d66be0d0f39e6
+    tag: 1.3.0
     enabled: false
   ptBRTelephony:
     catalogName: pt-BR_Telephony
     repository: watson-stt-pt-br-telephony
-    digest: sha256:25aa19014c47abc87c53b5fe85c1cab12b269b9a9e824c463b401e3f250f2fed
-    tag: 1.2.0
+    digest: sha256:b372a2f235509c89b525f1235c54a47fc6ba8b3a6718934535644fd8f4498867
+    tag: 1.3.0
     enabled: false
   zhCNTelephony:
     catalogName: zh-CN_Telephony
     repository: watson-stt-zh-cn-telephony
-    digest: sha256:a57a6b2b2b1c79529972fbffb01135b24d34796ebdb07323c367d9d553b0b7d0
-    tag: 1.2.0
+    digest: sha256:8f385685c7de97044df7252c206145e59a31d2dd929d9debb95143212a4c0f84
+    tag: 1.3.0
     enabled: false

--- a/charts/ibm-watson-tts-embed-runtime/values.yaml
+++ b/charts/ibm-watson-tts-embed-runtime/values.yaml
@@ -22,16 +22,16 @@ serviceType: ClusterIP
 images:
   runtime:
     repository: watson-tts-runtime
-    digest: sha256:38bc8e3fb30e447f28125a34a965b5962bf5981c9d5c85c51190f609843fb311
-    tag: 1.2.0
+    digest: sha256:ceb473dc09cdc1670bc491f8fcc7e91b592362b4cae309c38df24488b05fc2e6
+    tag: 1.3.0
   haproxy:
     repository: watson-tts-haproxy
-    digest: sha256:7ee4b9c918c7d17b2a9b13f932764696fec8b33d9c3ddc3132729998de7e2d4a
-    tag: 1.2.0
+    digest: sha256:9a51ac27563d6e047425a372c4dc26f31cea139a7329c600ee6e2b764f2ccba4
+    tag: 1.3.0
   catalog:
     repository: watson-tts-generic-models
-    digest: sha256:b26ac1a7a05967b0fffded11bfe00b68ab12a07aabb6fc4e58dc0bb0a85ba351
-    tag: 1.2.0
+    digest: sha256:9f070018be90367d8e2c9479a533970e13ab25049acc4619986a44b54446e258
+    tag: 1.3.0
 
 # resources sets per-container resource allocations
 resources:
@@ -62,162 +62,162 @@ models:
   deDEBirgitV3Voice:
     catalogName: de-DE_BirgitV3Voice
     repository: watson-tts-de-de-birgitv3voice
-    digest: sha256:e94bcd4e3be047d13424a264f5ce4e7f4cbc8ee07508e6c9ab9ab8a0f0f3b246
-    tag: 1.2.0
+    digest: sha256:292fe30580a5e8b62a17075a3f8abad429500faf7a3bf9c3e47b1dff32f0fe5e
+    tag: 1.3.0
     enabled: false
   deDEDieterV3Voice:
     catalogName: de-DE_DieterV3Voice
     repository: watson-tts-de-de-dieterv3voice
-    digest: sha256:87ef8e8bb926c9e475dd81aeddc1e4d53d9ce56d396fa93fd23cc80e00cdd132
-    tag: 1.2.0
+    digest: sha256:86dd7bb3327de10b665b80ecafe3218b12b78775708d871641c03673172318f6
+    tag: 1.3.0
     enabled: false
   deDEErikaV3Voice:
     catalogName: de-DE_ErikaV3Voice
     repository: watson-tts-de-de-erikav3voice
-    digest: sha256:9b5181d7733f1d93dff0b7a4e12b7f0712ae249b74058f86f4341231222a9b19
-    tag: 1.2.0
+    digest: sha256:ca1e08ff547437511a9dc2a63376bfe5aeed27d83ca447c15a77ebe01e0f6d6b
+    tag: 1.3.0
     enabled: false
   enGBCharlotteV3Voice:
     catalogName: en-GB_CharlotteV3Voice
     repository: watson-tts-en-gb-charlottev3voice
-    digest: sha256:fe14795c6005459c3a3a6fa46b64bd0c27057a79eb745bc00923eb67ee1d9a0e
-    tag: 1.2.0
+    digest: sha256:3126f72f6f35457f7324cf05079cf5de47bb43ec5c95fd2130ca5830223f276c
+    tag: 1.3.0
     enabled: false
   enGBJamesV3Voice:
     catalogName: en-GB_JamesV3Voice
     repository: watson-tts-en-gb-jamesv3voice
-    digest: sha256:59850f0b6e789b13f4cc30f061a7eae178866ea379797a36886d62d46b4545f4
-    tag: 1.2.0
+    digest: sha256:86df4691444c8b3edb5c31d71a06f475777cb319c2a000e85faed902be4e16e3
+    tag: 1.3.0
     enabled: false
   enGBKateV3Voice:
     catalogName: en-GB_KateV3Voice
     repository: watson-tts-en-gb-katev3voice
-    digest: sha256:c4c1f77e564f789a24f6570d3279eda3df1985d8eaa1b03d9823e58245a43ac3
-    tag: 1.2.0
+    digest: sha256:755066b57d0369d2262420e5c027b11c15e77d2c8ab4dd4550462bba7cc50c36
+    tag: 1.3.0
     enabled: false
   enUSAllisonExpressive:
     catalogName: en-US_AllisonExpressive
     repository: watson-tts-en-us-allisonexpressive
-    digest: sha256:922bdf359de91614aeade9d0486546933548fd1e1616fbe344208db05c641d09
-    tag: 1.2.0
+    digest: sha256:57e332aef890689b3d7d8fb41777878b7cafa448cc4c1e04a073c92ca525663b
+    tag: 1.3.0
     enabled: false
   enUSAllisonV3Voice:
     catalogName: en-US_AllisonV3Voice
     repository: watson-tts-en-us-allisonv3voice
-    digest: sha256:356ca753f6fa5ea4c93bc7d60a503ba10dbbb4a14fed2049f0eb9a0c4f487df0
-    tag: 1.2.0
+    digest: sha256:46ba1429150ed6877a9f25a2b7fc7da10f33aefab58db717b6cd7b7b4631639f
+    tag: 1.3.0
     enabled: true
   enUSEmilyV3Voice:
     catalogName: en-US_EmilyV3Voice
     repository: watson-tts-en-us-emilyv3voice
-    digest: sha256:4fbabf19465a3180b6e182d9fe9dfa77116bf4c949263d01e7c13067ef91681e
-    tag: 1.2.0
+    digest: sha256:8cbab7b025f234ebc521aadd5812a3e9673ef237f1cbe86b4c302cbf27dc4bff
+    tag: 1.3.0
     enabled: false
   enUSEmmaExpressive:
     catalogName: en-US_EmmaExpressive
     repository: watson-tts-en-us-emmaexpressive
-    digest: sha256:58fc5ef0d8d6b4612c3b6477f1a8a31172525ebebe9810863b355649c284d1e5
-    tag: 1.2.0
+    digest: sha256:89988e1d41180d0133a20b32c93a071db1c7c8359d5c786ff7f764fa9e6fa362
+    tag: 1.3.0
     enabled: false
   enUSHenryV3Voice:
     catalogName: en-US_HenryV3Voice
     repository: watson-tts-en-us-henryv3voice
-    digest: sha256:fe55351cecf6b39d106a6b6dc9ce4c250346dd8b00de1bead89a24a757a7e6b4
-    tag: 1.2.0
+    digest: sha256:25f0b1e37bb86fdfd7ba64dfa028ef39149c06b8c7d80a1b4bce10213f4bd069
+    tag: 1.3.0
     enabled: false
   enUSKevinV3Voice:
     catalogName: en-US_KevinV3Voice
     repository: watson-tts-en-us-kevinv3voice
-    digest: sha256:89224bb2ff590fbe61039038b52834b47078a2f36016622834d3812b45c5815c
-    tag: 1.2.0
+    digest: sha256:5ad2f735172dbec991a568ec2d1c1a1b20468e2453056c5571492fb13d63fab8
+    tag: 1.3.0
     enabled: false
   enUSLisaExpressive:
     catalogName: en-US_LisaExpressive
     repository: watson-tts-en-us-lisaexpressive
-    digest: sha256:26732c3b6fda44a5b4d074089b1962fcbbe43ae25404e9c2cbd985237afa2476
-    tag: 1.2.0
+    digest: sha256:989b01b256bc25d0176140591b94513ad7858dc88e6a6f32f7a6196d46d47b51
+    tag: 1.3.0
     enabled: false
   enUSLisaV3Voice:
     catalogName: en-US_LisaV3Voice
     repository: watson-tts-en-us-lisav3voice
-    digest: sha256:e30a5640e7515b5cd9b9a76942e737f5a17960cb0ed17f07727a60351c7a6d67
-    tag: 1.2.0
+    digest: sha256:dd275acc00b403a3930f7da87c0cb7c2de55be5dfcb93804078c52512aa30e86
+    tag: 1.3.0
     enabled: false
   enUSMichaelExpressive:
     catalogName: en-US_MichaelExpressive
     repository: watson-tts-en-us-michaelexpressive
-    digest: sha256:8388675838c8008932060128dac96ae95a144b6b88667ac8d9230f9620902abc
-    tag: 1.2.0
+    digest: sha256:2af344c2ddf75b104332ab777129de878c115b466f91770ec28f0c51642434ef
+    tag: 1.3.0
     enabled: false
   enUSMichaelV3Voice:
     catalogName: en-US_MichaelV3Voice
     repository: watson-tts-en-us-michaelv3voice
-    digest: sha256:79b80bc1f25a76065af9c0c4effb9030d53a1135af2178dade94c6b7638236b1
-    tag: 1.2.0
+    digest: sha256:ba928b3c7d0de206b4225b0a14e1f23e8d5db4f7728b99d634db1fd78535370e
+    tag: 1.3.0
     enabled: true
   enUSOliviaV3Voice:
     catalogName: en-US_OliviaV3Voice
     repository: watson-tts-en-us-oliviav3voice
-    digest: sha256:2951c7775ce82718bd296f98568934f2e5d54dc6d34cb3ea9efe8bb4c4af67cb
-    tag: 1.2.0
+    digest: sha256:5930cc025d8a2bad6221f945d6d291b5a4544df1c29c10e69a55ab2af24488fe
+    tag: 1.3.0
     enabled: false
   esESEnriqueV3Voice:
     catalogName: es-ES_EnriqueV3Voice
     repository: watson-tts-es-es-enriquev3voice
-    digest: sha256:0b4b3719ea8fbae4d5b8b596d1759d4d70eabedb1548ca6260600737b52cf258
-    tag: 1.2.0
+    digest: sha256:c9fc06dbe0c83783f3cae162ef7d5e62623e52b71da5c9d4062940ed140670a8
+    tag: 1.3.0
     enabled: false
   esESLauraV3Voice:
     catalogName: es-ES_LauraV3Voice
     repository: watson-tts-es-es-laurav3voice
-    digest: sha256:988999ccacd796991133adf517c3b6eda59ddd580dcbc37645fd35645e270aa5
-    tag: 1.2.0
+    digest: sha256:c440312f1a346801c1a3e5dda246ab501c04596e2d63fdd1904e1eab72fdb305
+    tag: 1.3.0
     enabled: false
   esLASofiaV3Voice:
     catalogName: es-LA_SofiaV3Voice
     repository: watson-tts-es-la-sofiav3voice
-    digest: sha256:8bea30a8e1ae003a25f671888c166fd9a2931f016b0f5a3983b9aa130332955f
-    tag: 1.2.0
+    digest: sha256:c16b85b88102c867de220508f8565ceef7768f181629355f0a6bd13f857e44f3
+    tag: 1.3.0
     enabled: false
   esUSSofiaV3Voice:
     catalogName: es-US_SofiaV3Voice
     repository: watson-tts-es-us-sofiav3voice
-    digest: sha256:abfa5e8d30ffde31d7c43c56c3672c7db7d9e4aaaec643a4af48de448ec50d6d
-    tag: 1.2.0
+    digest: sha256:972018dfe32c96ace83501d7ff8db817eada6594c0e7b3270a71359437232366
+    tag: 1.3.0
     enabled: false
   frCALouiseV3Voice:
     catalogName: fr-CA_LouiseV3Voice
     repository: watson-tts-fr-ca-louisev3voice
-    digest: sha256:2508d1de564fa8d6e4992400ee57c6f97b00fc894f3a65c6e40057b192f63b20
-    tag: 1.2.0
+    digest: sha256:3d9a4020bc70aab38c68ba2157892f8fc8b47adc2e2c61ee9530ed08a23f236c
+    tag: 1.3.0
     enabled: false
   frFRNicolasV3Voice:
     catalogName: fr-FR_NicolasV3Voice
     repository: watson-tts-fr-fr-nicolasv3voice
-    digest: sha256:1167ffd276bf0c4ddbc7e415142de25283d3cdf9d94640a193f7d27ffafb00cf
-    tag: 1.2.0
+    digest: sha256:fafc117b22fd9d922a3398e121db0cf3a938814e051b686a0194b0d04c59dad0
+    tag: 1.3.0
     enabled: false
   frFRReneeV3Voice:
     catalogName: fr-FR_ReneeV3Voice
     repository: watson-tts-fr-fr-reneev3voice
-    digest: sha256:c9127b69ed8eec5657e4fb3572abe92032a40d2a33f621105f8e2152f6f297e1
-    tag: 1.2.0
+    digest: sha256:03e7c422846f00416102f49a70156f4062ddc64b877ad3de96cbe5a448f83d38
+    tag: 1.3.0
     enabled: false
   itITFrancescaV3Voice:
     catalogName: it-IT_FrancescaV3Voice
     repository: watson-tts-it-it-francescav3voice
-    digest: sha256:821a8da616c47f47720e3fa5accfe7ed4f1c3cf2eb363b07815b2a74b182fc10
-    tag: 1.2.0
+    digest: sha256:0bd8320e3702693c875a1af5b873781948b05d9edae344bc7bebe33390a15f14
+    tag: 1.3.0
     enabled: false
   jaJPEmiV3Voice:
     catalogName: ja-JP_EmiV3Voice
     repository: watson-tts-ja-jp-emiv3voice
-    digest: sha256:f339568a8769812476d06d8a83a8490e19dd5b2cfb6fa38fc50f21601aaa6838
-    tag: 1.2.0
+    digest: sha256:a4b9ad3665597f94e890eb059a302acd53ed389b92e9a902ba34a1b612525f7a
+    tag: 1.3.0
     enabled: false
   ptBRIsabelaV3Voice:
     catalogName: pt-BR_IsabelaV3Voice
     repository: watson-tts-pt-br-isabelav3voice
-    digest: sha256:b319ca65d0ff4db2194924b657d5d544dcf110cccb1764664d49f75b5af9d8b5
-    tag: 1.2.0
+    digest: sha256:1aa66b48a509402349ce7d2069aa32f46cdfda090e360a4200b0aed271e1b6b4
+    tag: 1.3.0
     enabled: false

--- a/charts/ibm-watson-tts-embed/templates/runtime/deployment.yaml
+++ b/charts/ibm-watson-tts-embed/templates/runtime/deployment.yaml
@@ -5,6 +5,9 @@
 {{- /* Construct the list of enabled models */}}
 {{- $enabledModels := (include "ibm-embed-helpers.enabledModelImageConfigs" .) | fromYamlArray }}
 {{- $modelsList := (list) }}
+{{- if .Values.customizationEnabled }}
+  {{- $modelsList = append $modelsList "TuneByExampleModel" }}
+{{- end }}
 {{- range $enabledModels }}
   {{- $modelsList = append $modelsList .catalogName }}
 {{- end }}

--- a/charts/ibm-watson-tts-embed/templates/tests/job.yaml
+++ b/charts/ibm-watson-tts-embed/templates/tests/job.yaml
@@ -15,6 +15,9 @@ spec:
       labels:
         {{- include "ibm-watson-tts-embed.tests.labels" . | nindent 8 }}
     spec:
+      {{- include "ibm-embed-helpers.podSecurityContext" . | nindent 6 -}}
+      imagePullSecrets:
+        {{- .Values.imagePullSecrets | toYaml | nindent 8 }}
       restartPolicy: Never
       containers:
         - name: healthchecks

--- a/charts/ibm-watson-tts-embed/values.yaml
+++ b/charts/ibm-watson-tts-embed/values.yaml
@@ -85,191 +85,197 @@ resources:
 images:
   utils:
     repository: watson-tts-utils
-    digest: sha256:f2de65a4c3046349bbdd975c7de4cfb5a87b04ca1155139e4f3877365d688370
-    tag: 1.2.0
+    digest: sha256:bd242a0157e17b7cb72cddf0795415b7b3386769415a47cae982707add5f2c1b
+    tag: 1.3.0
   runtime:
     repository: watson-tts-runtime
-    digest: sha256:38bc8e3fb30e447f28125a34a965b5962bf5981c9d5c85c51190f609843fb311
-    tag: 1.2.0
+    digest: sha256:ceb473dc09cdc1670bc491f8fcc7e91b592362b4cae309c38df24488b05fc2e6
+    tag: 1.3.0
   haproxy:
     repository: watson-tts-haproxy
-    digest: sha256:7ee4b9c918c7d17b2a9b13f932764696fec8b33d9c3ddc3132729998de7e2d4a
-    tag: 1.2.0
+    digest: sha256:9a51ac27563d6e047425a372c4dc26f31cea139a7329c600ee6e2b764f2ccba4
+    tag: 1.3.0
   customization:
     repository: watson-tts-customization
-    digest: sha256:a4ad44bf31224fdef76b983158efb9c14d03d42ab23e27f5fe2fdcfabb3fd83d
-    tag: 1.2.0
+    digest: sha256:304a88e0a373ba9d34f035e0a5c6df7e98851c2b27d22d1951e8601ce39b9faa
+    tag: 1.3.0
   catalog:
     repository: watson-tts-generic-models
-    digest: sha256:b26ac1a7a05967b0fffded11bfe00b68ab12a07aabb6fc4e58dc0bb0a85ba351
-    tag: 1.2.0
+    digest: sha256:9f070018be90367d8e2c9479a533970e13ab25049acc4619986a44b54446e258
+    tag: 1.3.0
 
 # defaultModel will be used if no voice is included in the /synthesize request
 defaultModel: en-US_AllisonV3Voice
 # modelVersion sets the path within model storage where the catalog will be uploaded
-modelVersion: "1.1.0"
+modelVersion: "1.3.0"
 # models has configuration for model container images and model enablement
 # To pull by tag, set digest to the empty string
 models:
   deDEBirgitV3Voice:
     catalogName: de-DE_BirgitV3Voice
     repository: watson-tts-de-de-birgitv3voice
-    digest: sha256:e94bcd4e3be047d13424a264f5ce4e7f4cbc8ee07508e6c9ab9ab8a0f0f3b246
-    tag: 1.2.0
+    digest: sha256:292fe30580a5e8b62a17075a3f8abad429500faf7a3bf9c3e47b1dff32f0fe5e
+    tag: 1.3.0
     enabled: false
   deDEDieterV3Voice:
     catalogName: de-DE_DieterV3Voice
     repository: watson-tts-de-de-dieterv3voice
-    digest: sha256:87ef8e8bb926c9e475dd81aeddc1e4d53d9ce56d396fa93fd23cc80e00cdd132
-    tag: 1.2.0
+    digest: sha256:86dd7bb3327de10b665b80ecafe3218b12b78775708d871641c03673172318f6
+    tag: 1.3.0
     enabled: false
   deDEErikaV3Voice:
     catalogName: de-DE_ErikaV3Voice
     repository: watson-tts-de-de-erikav3voice
-    digest: sha256:9b5181d7733f1d93dff0b7a4e12b7f0712ae249b74058f86f4341231222a9b19
-    tag: 1.2.0
+    digest: sha256:ca1e08ff547437511a9dc2a63376bfe5aeed27d83ca447c15a77ebe01e0f6d6b
+    tag: 1.3.0
     enabled: false
   enGBCharlotteV3Voice:
     catalogName: en-GB_CharlotteV3Voice
     repository: watson-tts-en-gb-charlottev3voice
-    digest: sha256:fe14795c6005459c3a3a6fa46b64bd0c27057a79eb745bc00923eb67ee1d9a0e
-    tag: 1.2.0
+    digest: sha256:3126f72f6f35457f7324cf05079cf5de47bb43ec5c95fd2130ca5830223f276c
+    tag: 1.3.0
     enabled: false
   enGBJamesV3Voice:
     catalogName: en-GB_JamesV3Voice
     repository: watson-tts-en-gb-jamesv3voice
-    digest: sha256:59850f0b6e789b13f4cc30f061a7eae178866ea379797a36886d62d46b4545f4
-    tag: 1.2.0
+    digest: sha256:86df4691444c8b3edb5c31d71a06f475777cb319c2a000e85faed902be4e16e3
+    tag: 1.3.0
     enabled: false
   enGBKateV3Voice:
     catalogName: en-GB_KateV3Voice
     repository: watson-tts-en-gb-katev3voice
-    digest: sha256:c4c1f77e564f789a24f6570d3279eda3df1985d8eaa1b03d9823e58245a43ac3
-    tag: 1.2.0
+    digest: sha256:755066b57d0369d2262420e5c027b11c15e77d2c8ab4dd4550462bba7cc50c36
+    tag: 1.3.0
     enabled: false
   enUSAllisonExpressive:
     catalogName: en-US_AllisonExpressive
     repository: watson-tts-en-us-allisonexpressive
-    digest: sha256:922bdf359de91614aeade9d0486546933548fd1e1616fbe344208db05c641d09
-    tag: 1.2.0
+    digest: sha256:57e332aef890689b3d7d8fb41777878b7cafa448cc4c1e04a073c92ca525663b
+    tag: 1.3.0
     enabled: false
   enUSAllisonV3Voice:
     catalogName: en-US_AllisonV3Voice
     repository: watson-tts-en-us-allisonv3voice
-    digest: sha256:356ca753f6fa5ea4c93bc7d60a503ba10dbbb4a14fed2049f0eb9a0c4f487df0
-    tag: 1.2.0
+    digest: sha256:46ba1429150ed6877a9f25a2b7fc7da10f33aefab58db717b6cd7b7b4631639f
+    tag: 1.3.0
     enabled: true
   enUSEmilyV3Voice:
     catalogName: en-US_EmilyV3Voice
     repository: watson-tts-en-us-emilyv3voice
-    digest: sha256:4fbabf19465a3180b6e182d9fe9dfa77116bf4c949263d01e7c13067ef91681e
-    tag: 1.2.0
+    digest: sha256:8cbab7b025f234ebc521aadd5812a3e9673ef237f1cbe86b4c302cbf27dc4bff
+    tag: 1.3.0
     enabled: false
   enUSEmmaExpressive:
     catalogName: en-US_EmmaExpressive
     repository: watson-tts-en-us-emmaexpressive
-    digest: sha256:58fc5ef0d8d6b4612c3b6477f1a8a31172525ebebe9810863b355649c284d1e5
-    tag: 1.2.0
+    digest: sha256:89988e1d41180d0133a20b32c93a071db1c7c8359d5c786ff7f764fa9e6fa362
+    tag: 1.3.0
     enabled: false
   enUSHenryV3Voice:
     catalogName: en-US_HenryV3Voice
     repository: watson-tts-en-us-henryv3voice
-    digest: sha256:fe55351cecf6b39d106a6b6dc9ce4c250346dd8b00de1bead89a24a757a7e6b4
-    tag: 1.2.0
+    digest: sha256:25f0b1e37bb86fdfd7ba64dfa028ef39149c06b8c7d80a1b4bce10213f4bd069
+    tag: 1.3.0
     enabled: false
   enUSKevinV3Voice:
     catalogName: en-US_KevinV3Voice
     repository: watson-tts-en-us-kevinv3voice
-    digest: sha256:89224bb2ff590fbe61039038b52834b47078a2f36016622834d3812b45c5815c
-    tag: 1.2.0
+    digest: sha256:5ad2f735172dbec991a568ec2d1c1a1b20468e2453056c5571492fb13d63fab8
+    tag: 1.3.0
     enabled: false
   enUSLisaExpressive:
     catalogName: en-US_LisaExpressive
     repository: watson-tts-en-us-lisaexpressive
-    digest: sha256:26732c3b6fda44a5b4d074089b1962fcbbe43ae25404e9c2cbd985237afa2476
-    tag: 1.2.0
+    digest: sha256:989b01b256bc25d0176140591b94513ad7858dc88e6a6f32f7a6196d46d47b51
+    tag: 1.3.0
     enabled: false
   enUSLisaV3Voice:
     catalogName: en-US_LisaV3Voice
     repository: watson-tts-en-us-lisav3voice
-    digest: sha256:e30a5640e7515b5cd9b9a76942e737f5a17960cb0ed17f07727a60351c7a6d67
-    tag: 1.2.0
+    digest: sha256:dd275acc00b403a3930f7da87c0cb7c2de55be5dfcb93804078c52512aa30e86
+    tag: 1.3.0
     enabled: false
   enUSMichaelExpressive:
     catalogName: en-US_MichaelExpressive
     repository: watson-tts-en-us-michaelexpressive
-    digest: sha256:8388675838c8008932060128dac96ae95a144b6b88667ac8d9230f9620902abc
-    tag: 1.2.0
+    digest: sha256:2af344c2ddf75b104332ab777129de878c115b466f91770ec28f0c51642434ef
+    tag: 1.3.0
     enabled: false
   enUSMichaelV3Voice:
     catalogName: en-US_MichaelV3Voice
     repository: watson-tts-en-us-michaelv3voice
-    digest: sha256:79b80bc1f25a76065af9c0c4effb9030d53a1135af2178dade94c6b7638236b1
-    tag: 1.2.0
+    digest: sha256:ba928b3c7d0de206b4225b0a14e1f23e8d5db4f7728b99d634db1fd78535370e
+    tag: 1.3.0
     enabled: true
   enUSOliviaV3Voice:
     catalogName: en-US_OliviaV3Voice
     repository: watson-tts-en-us-oliviav3voice
-    digest: sha256:2951c7775ce82718bd296f98568934f2e5d54dc6d34cb3ea9efe8bb4c4af67cb
-    tag: 1.2.0
+    digest: sha256:5930cc025d8a2bad6221f945d6d291b5a4544df1c29c10e69a55ab2af24488fe
+    tag: 1.3.0
     enabled: false
   esESEnriqueV3Voice:
     catalogName: es-ES_EnriqueV3Voice
     repository: watson-tts-es-es-enriquev3voice
-    digest: sha256:0b4b3719ea8fbae4d5b8b596d1759d4d70eabedb1548ca6260600737b52cf258
-    tag: 1.2.0
+    digest: sha256:c9fc06dbe0c83783f3cae162ef7d5e62623e52b71da5c9d4062940ed140670a8
+    tag: 1.3.0
     enabled: false
   esESLauraV3Voice:
     catalogName: es-ES_LauraV3Voice
     repository: watson-tts-es-es-laurav3voice
-    digest: sha256:988999ccacd796991133adf517c3b6eda59ddd580dcbc37645fd35645e270aa5
-    tag: 1.2.0
+    digest: sha256:c440312f1a346801c1a3e5dda246ab501c04596e2d63fdd1904e1eab72fdb305
+    tag: 1.3.0
     enabled: false
   esLASofiaV3Voice:
     catalogName: es-LA_SofiaV3Voice
     repository: watson-tts-es-la-sofiav3voice
-    digest: sha256:8bea30a8e1ae003a25f671888c166fd9a2931f016b0f5a3983b9aa130332955f
-    tag: 1.2.0
+    digest: sha256:c16b85b88102c867de220508f8565ceef7768f181629355f0a6bd13f857e44f3
+    tag: 1.3.0
     enabled: false
   esUSSofiaV3Voice:
     catalogName: es-US_SofiaV3Voice
     repository: watson-tts-es-us-sofiav3voice
-    digest: sha256:abfa5e8d30ffde31d7c43c56c3672c7db7d9e4aaaec643a4af48de448ec50d6d
-    tag: 1.2.0
+    digest: sha256:972018dfe32c96ace83501d7ff8db817eada6594c0e7b3270a71359437232366
+    tag: 1.3.0
     enabled: false
   frCALouiseV3Voice:
     catalogName: fr-CA_LouiseV3Voice
     repository: watson-tts-fr-ca-louisev3voice
-    digest: sha256:2508d1de564fa8d6e4992400ee57c6f97b00fc894f3a65c6e40057b192f63b20
-    tag: 1.2.0
+    digest: sha256:3d9a4020bc70aab38c68ba2157892f8fc8b47adc2e2c61ee9530ed08a23f236c
+    tag: 1.3.0
     enabled: false
   frFRNicolasV3Voice:
     catalogName: fr-FR_NicolasV3Voice
     repository: watson-tts-fr-fr-nicolasv3voice
-    digest: sha256:1167ffd276bf0c4ddbc7e415142de25283d3cdf9d94640a193f7d27ffafb00cf
-    tag: 1.2.0
+    digest: sha256:fafc117b22fd9d922a3398e121db0cf3a938814e051b686a0194b0d04c59dad0
+    tag: 1.3.0
     enabled: false
   frFRReneeV3Voice:
     catalogName: fr-FR_ReneeV3Voice
     repository: watson-tts-fr-fr-reneev3voice
-    digest: sha256:c9127b69ed8eec5657e4fb3572abe92032a40d2a33f621105f8e2152f6f297e1
-    tag: 1.2.0
+    digest: sha256:03e7c422846f00416102f49a70156f4062ddc64b877ad3de96cbe5a448f83d38
+    tag: 1.3.0
     enabled: false
   itITFrancescaV3Voice:
     catalogName: it-IT_FrancescaV3Voice
     repository: watson-tts-it-it-francescav3voice
-    digest: sha256:821a8da616c47f47720e3fa5accfe7ed4f1c3cf2eb363b07815b2a74b182fc10
-    tag: 1.2.0
+    digest: sha256:0bd8320e3702693c875a1af5b873781948b05d9edae344bc7bebe33390a15f14
+    tag: 1.3.0
     enabled: false
   jaJPEmiV3Voice:
     catalogName: ja-JP_EmiV3Voice
     repository: watson-tts-ja-jp-emiv3voice
-    digest: sha256:f339568a8769812476d06d8a83a8490e19dd5b2cfb6fa38fc50f21601aaa6838
-    tag: 1.2.0
+    digest: sha256:a4b9ad3665597f94e890eb059a302acd53ed389b92e9a902ba34a1b612525f7a
+    tag: 1.3.0
     enabled: false
   ptBRIsabelaV3Voice:
     catalogName: pt-BR_IsabelaV3Voice
     repository: watson-tts-pt-br-isabelav3voice
-    digest: sha256:b319ca65d0ff4db2194924b657d5d544dcf110cccb1764664d49f75b5af9d8b5
-    tag: 1.2.0
+    digest: sha256:1aa66b48a509402349ce7d2069aa32f46cdfda090e360a4200b0aed271e1b6b4
+    tag: 1.3.0
     enabled: false
+  tuneByExampleModel:
+    catalogName: TuneByExampleModel
+    repository: watson-tts-tunebyexamplemodel
+    digest: sha256:25029295f20ae202786e8346d0ee061b43ff0665556b3f80c58bbbee3fe30239
+    tag: 1.3.0
+    enabled: true


### PR DESCRIPTION
Sync out changes to the Helm charts to support the new 1.3.0 release of the Watson Speech to Text and Text to Speech Library for Embed products.

Changes include:
- update all image references to 1.3.0 images
- add new TuneByExample TTS model for customization
- update test Jobs, missing some fields from the pod spec: `imagePullSecrets` and `podSecurityContext`

