### PR TITLE
fix: update model cp commands for new pool dir

### DIFF
--- a/charts/ibm-watson-stt-embed-runtime/templates/deployment.yaml
+++ b/charts/ibm-watson-stt-embed-runtime/templates/deployment.yaml
@@ -60,10 +60,10 @@ spec:
         args:
         - sh
         - -c
-        - cp model/* /models/pool2
+        - cp -r model/* /models/
         volumeMounts:
         - name: chuck-models
-          mountPath: /models/pool2
+          mountPath: /models/
       {{- end }}
 
       - name: prepare-models
@@ -88,7 +88,7 @@ spec:
         - name: chuck-logs
           mountPath: /opt/ibm/chuck.x86_64/logs
         - name: chuck-models
-          mountPath: /models/pool2
+          mountPath: /models/
         - name: tmp
           mountPath: /tmp
 

--- a/charts/ibm-watson-tts-embed-runtime/templates/deployment.yaml
+++ b/charts/ibm-watson-tts-embed-runtime/templates/deployment.yaml
@@ -60,10 +60,10 @@ spec:
         args:
         - sh
         - -c
-        - cp model/* /models/pool2
+        - cp -r model/* /models/
         volumeMounts:
         - name: chuck-models
-          mountPath: /models/pool2
+          mountPath: /models/
       {{- end }}
 
       - name: prepare-models
@@ -88,7 +88,7 @@ spec:
         - name: chuck-logs
           mountPath: /opt/ibm/chuck.x86_64/logs
         - name: chuck-models
-          mountPath: /models/pool2
+          mountPath: /models/
         - name: tmp
           mountPath: /tmp
 


### PR DESCRIPTION
The 1.6.0 STT model images added a directory to /model/. This change is needed to ensure that all model files are copied over for use in the runtime only charts.

Resolves https://github.com/IBM/ibm-watson-embed-charts/issues/10